### PR TITLE
App verdrahten: ContentView → echte TabView (RT60/Scan/Maße/Material/Export)

### DIFF
--- a/AcoustiScanApp/AcoustiScanApp/App/ContentView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/App/ContentView.swift
@@ -1,27 +1,102 @@
 //
 //  ContentView.swift
-//  iPadScannerApp
+//  AcoustiScanApp
 //
-//  Created by Marc Schneider-Handrup on 26.05.25.
+//  Root navigation: tab-based access to RT60 analysis, room scanning,
+//  manual room dimensions, material editing and export.
 //
 
 import SwiftUI
 
 struct ContentView: View {
+    /// Shared model holding scanned/edited surfaces and the room volume.
+    @StateObject private var store = SurfaceStore()
+
+    /// Library of acoustic materials used by the material editor.
+    @StateObject private var materialManager = MaterialManager()
+
+    // Manual room-dimension entry (used when no LiDAR scan is available).
+    @State private var roomLength: Double = 5.0
+    @State private var roomWidth: Double = 4.0
+    @State private var roomHeight: Double = 2.7
+
+    #if canImport(RoomPlan)
+    /// Coordinator driving the RoomPlan LiDAR capture session.
+    @StateObject private var scanCoordinator = RoomScanCoordinator()
+    #endif
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-                .accessibilityLabel("Globe icon")
-                .accessibilityIdentifier("globeIcon")
-            Text("Hello, world!")
-                .accessibilityLabel("Hello, world!")
-                .accessibilityIdentifier("welcomeText")
+        TabView {
+            NavigationStack {
+                RT60View(store: store)
+                    .navigationTitle("RT60")
+            }
+            .tabItem {
+                Label("RT60", systemImage: "waveform")
+            }
+            .accessibilityIdentifier("tabRT60")
+
+            NavigationStack {
+                scannerTab
+            }
+            .tabItem {
+                Label("Scan", systemImage: "camera.viewfinder")
+            }
+            .accessibilityIdentifier("tabScan")
+
+            NavigationStack {
+                RoomDimensionView(length: $roomLength, width: $roomWidth, height: $roomHeight)
+                    .navigationTitle("Maße")
+            }
+            .tabItem {
+                Label("Maße", systemImage: "ruler")
+            }
+            .accessibilityIdentifier("tabDimensions")
+
+            NavigationStack {
+                MaterialEditorView(materialManager: materialManager)
+                    .navigationTitle("Material")
+            }
+            .tabItem {
+                Label("Material", systemImage: "square.stack.3d.up")
+            }
+            .accessibilityIdentifier("tabMaterials")
+
+            NavigationStack {
+                ExportView(store: store)
+                    .navigationTitle("Export")
+            }
+            .tabItem {
+                Label("Export", systemImage: "square.and.arrow.up")
+            }
+            .accessibilityIdentifier("tabExport")
         }
-        .padding()
-        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("contentView")
+        .onAppear(perform: syncRoomVolume)
+        .onChange(of: roomLength) { _, _ in syncRoomVolume() }
+        .onChange(of: roomWidth) { _, _ in syncRoomVolume() }
+        .onChange(of: roomHeight) { _, _ in syncRoomVolume() }
+    }
+
+    /// Scanner tab: real RoomPlan capture where available, otherwise a fallback
+    /// that explains the requirement and relies on manual dimension entry.
+    @ViewBuilder
+    private var scannerTab: some View {
+        #if canImport(RoomPlan)
+        RoomScanView(coordinator: scanCoordinator)
+            .navigationTitle("Scan")
+            .onAppear { scanCoordinator.store = store }
+        #else
+        RoomScanView(store: store)
+            .navigationTitle("Scan")
+        #endif
+    }
+
+    /// Keep the shared room volume in sync with the manual dimension entry so
+    /// the RT60 calculation has a volume even without a LiDAR scan.
+    private func syncRoomVolume() {
+        store.roomVolume = roomLength * roomWidth * roomHeight
+        store.roomDimensions = (width: roomWidth, height: roomHeight, depth: roomLength)
     }
 }
 

--- a/AcoustiScanApp/AcoustiScanAppTests/AcoustiScanUITests.swift
+++ b/AcoustiScanApp/AcoustiScanAppTests/AcoustiScanUITests.swift
@@ -462,8 +462,11 @@ class AcoustiScanUITests: XCTestCase {
         // Verify ContentView accessibility identifiers
         let contentViewIdentifiers = [
             "contentView",
-            "globeIcon",
-            "welcomeText"
+            "tabRT60",
+            "tabScan",
+            "tabDimensions",
+            "tabMaterials",
+            "tabExport"
         ]
 
         for identifier in contentViewIdentifiers {


### PR DESCRIPTION
## Ziel
Nächstes Increment nach der gemergten Sanierung (#248): die App **funktional verdrahten**. Bisher kompilierte sie zwar (Engpass beseitigt), zeigte zur Laufzeit aber nur den Xcode-Platzhalter `Hello, world!`.

## Änderung
`ContentView` ist jetzt eine echte `TabView`, die den geteilten Zustand besitzt und die bereits vorhandenen Feature-Views einbindet:

| Tab | View | Abhängigkeit |
|-----|------|--------------|
| RT60 | `RT60View` | `SurfaceStore` |
| Scan | `RoomScanView` | RoomPlan-Coordinator (mit Simulator-Fallback via `#if canImport(RoomPlan)`) |
| Maße | `RoomDimensionView` | manuelle Maße (Bindings) |
| Material | `MaterialEditorView` | `MaterialManager` |
| Export | `ExportView` | `SurfaceStore` |

- `SurfaceStore` und `MaterialManager` als `@StateObject` in `ContentView`.
- Manuelle Raummaße werden in `store.roomVolume`/`roomDimensions` gespiegelt, damit die RT60-Berechnung **auch ohne LiDAR-Scan** ein Volumen hat.
- Der triviale Accessibility-ID-Test wurde von den alten Hello-World-IDs (`globeIcon`/`welcomeText`) auf die neuen Tab-IDs umgestellt.

## Verifikation
Die ehrliche CI (`ci-honest.yml`) baut die iOS-App via `xcodebuild` (iphonesimulator) — der Build dieses PRs ist die Bestätigung, dass die Verdrahtung kompiliert.

## Hinweis
Funktionaler Tiefgang (DIN-Engine normtreu, Modell-Konsolidierung) folgt in separaten Increments.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_