### PR TITLE
DIN 18041 normtreu: A1–A5, echte Sollwertgleichungen + Bild-2-Toleranzband

### DIFF
--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/DIN18041/DIN18041Database.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/DIN18041/DIN18041Database.swift
@@ -1,165 +1,33 @@
 // DIN18041Database.swift
-// DIN 18041 target database for different room types
-// Implements volume-dependent RT60 targets according to DIN 18041 standard
+// Volume- and frequency-dependent RT60 targets per DIN 18041:2016-03 (Gruppe A).
 
 import Foundation
 
-/// DIN 18041 target database with volume-dependent calculations
+/// Builds DIN 18041:2016-03 reverberation-time targets for a usage group.
+///
+/// The mid-band target `T_soll = a · lg(V) + b` comes from `RoomType`
+/// (equations (1)–(6)); the per-octave acceptable range is derived from the
+/// Bild 2 tolerance ratios. All normative constants live on `RoomType`, so this
+/// type only assembles the per-frequency `DIN18041Target` values.
 public struct DIN18041Database {
 
-    /// Reference volume for base RT60 values (100 m3 is typical reference)
-    private static let referenceVolume: Double = 100.0
-
-    /// Get DIN 18041 targets for specific room type and volume
-    public static func targets(for roomType: RoomType, volume: Double) -> [DIN18041Target] {
-        switch roomType {
-        case .classroom:
-            return classroomTargets(volume: volume)
-        case .officeSpace:
-            return officeTargets(volume: volume)
-        case .conference:
-            return conferenceTargets(volume: volume)
-        case .lecture:
-            return lectureTargets(volume: volume)
-        case .music:
-            return musicTargets(volume: volume)
-        case .sports:
-            return sportsTargets(volume: volume)
-        }
-    }
-
-    /// Calculate volume-adjusted RT60 target using DIN 18041 formula
-    /// T_soll = T_base * (V / V_ref)^exponent
+    /// DIN 18041 targets for a usage group and room volume.
+    ///
     /// - Parameters:
-    ///   - baseRT60: Base RT60 value for reference volume
-    ///   - volume: Actual room volume in m3
-    ///   - exponent: Volume scaling exponent (typically 0.05-0.15)
-    /// - Returns: Volume-adjusted RT60 target
-    private static func volumeAdjustedRT60(baseRT60: Double, volume: Double, exponent: Double = 0.1) -> Double {
-        guard volume > 0 else { return baseRT60 }
-        let ratio = volume / referenceVolume
-        // Apply logarithmic scaling: larger rooms need proportionally longer RT60
-        return baseRT60 * pow(ratio, exponent)
-    }
+    ///   - roomType: DIN 18041 usage group (A1–A5).
+    ///   - volume: Room volume in m³.
+    /// - Returns: One target per evaluated octave band for the group.
+    public static func targets(for roomType: RoomType, volume: Double) -> [DIN18041Target] {
+        let targetRT60 = roomType.targetReverberationTime(volume: volume)
 
-    private static func classroomTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Classrooms require speech intelligibility
-        // Base RT60 = 0.6s for 100 m3, with volume scaling exponent 0.08
-        let baseRT60 = 0.6
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.08)
-        let tolerance = 0.1
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Frequency-dependent adjustments per DIN 18041
-            if frequency <= 250 {
-                targetRT60 *= 1.2 // Allow slightly higher RT60 at low frequencies
-            } else if frequency >= 2000 {
-                targetRT60 *= 0.8 // Require lower RT60 at high frequencies for clarity
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
-        }
-    }
-
-    private static func officeTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Open plan offices need acoustic privacy
-        // Base RT60 = 0.5s, lower exponent (0.05) as offices vary less with size
-        let baseRT60 = 0.5
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.05)
-        let tolerance = 0.1
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Speech-frequency optimization
-            if frequency >= 500 && frequency <= 2000 {
-                targetRT60 *= 0.95 // Slightly lower in speech range
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
-        }
-    }
-
-    private static func conferenceTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Conference rooms need good speech intelligibility
-        // Base RT60 = 0.7s with moderate volume scaling
-        let baseRT60 = 0.7
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.1)
-        let tolerance = 0.15
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Optimize for speech frequencies
-            if frequency >= 500 && frequency <= 4000 {
-                targetRT60 *= 0.9
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
-        }
-    }
-
-    private static func lectureTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Lecture halls need projection but clarity
-        // Base RT60 = 0.8s with higher volume scaling for larger auditoriums
-        let baseRT60 = 0.8
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.12)
-        let tolerance = 0.15
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Frequency-dependent adjustments for lecture clarity
-            if frequency <= 250 {
-                targetRT60 *= 1.1 // Allow some warmth at low frequencies
-            } else if frequency >= 4000 {
-                targetRT60 *= 0.85 // Control high-frequency reflections
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
-        }
-    }
-
-    private static func musicTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Music rooms need longer reverberation for richness
-        // Base RT60 = 1.5s with significant volume scaling
-        let baseRT60 = 1.5
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.15)
-        let tolerance = 0.2
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Music benefits from balanced frequency response
-            if frequency <= 125 {
-                targetRT60 *= 1.15 // Fuller bass response
-            } else if frequency >= 4000 {
-                targetRT60 *= 0.9 // Controlled brilliance
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
-        }
-    }
-
-    private static func sportsTargets(volume: Double) -> [DIN18041Target] {
-        // DIN 18041: Sports halls prioritize speech/announcement clarity
-        // Base RT60 = 2.0s but with strict volume scaling for large spaces
-        let baseRT60 = 2.0
-        let volumeAdjusted = volumeAdjustedRT60(baseRT60: baseRT60, volume: volume, exponent: 0.12)
-        // Larger tolerance for sports halls due to their size and variable use
-        let tolerance = 0.3
-
-        return [125, 250, 500, 1000, 2000, 4000, 8000].map { frequency in
-            var targetRT60 = volumeAdjusted
-
-            // Optimize for PA announcements
-            if frequency >= 500 && frequency <= 2000 {
-                targetRT60 *= 0.9 // Better speech clarity in PA range
-            }
-
-            return DIN18041Target(frequency: frequency, targetRT60: targetRT60, tolerance: tolerance)
+        return roomType.evaluationFrequencies.map { frequency in
+            let ratios = roomType.toleranceRatios(at: frequency)
+            return DIN18041Target(
+                frequency: frequency,
+                targetRT60: targetRT60,
+                lowerRatio: ratios.lower,
+                upperRatio: ratios.upper
+            )
         }
     }
 }

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/DIN18041/RT60Evaluator.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/DIN18041/RT60Evaluator.swift
@@ -19,16 +19,7 @@ public struct RT60Evaluator {
                 return nil
             }
 
-            let diff = measurement.rt60 - target.targetRT60
-            let status: EvaluationStatus
-
-            if abs(diff) <= target.tolerance {
-                status = .withinTolerance
-            } else if diff > 0 {
-                status = .tooHigh
-            } else {
-                status = .tooLow
-            }
+            let status = target.evaluateCompliance(measurement.rt60)
 
             return RT60Deviation(
                 frequency: measurement.frequency,

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Models/DIN18041Target.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Models/DIN18041Target.swift
@@ -3,52 +3,50 @@
 
 import Foundation
 
-/// DIN 18041 target RT60 value with tolerance for a specific frequency
+/// DIN 18041 target RT60 with an (asymmetric) tolerance band for one octave.
 ///
-/// This structure represents the target reverberation time and tolerance
-/// for a specific frequency band according to DIN 18041 standard.
+/// The tolerance per DIN 18041:2016-03 Bild 2 is expressed as a ratio of the
+/// measured RT60 to the target `T_soll` and is generally asymmetric (e.g.
+/// 0.65–1.45 at the band edges), so the acceptable range is stored as explicit
+/// lower/upper bounds in seconds rather than a single symmetric tolerance.
 public struct DIN18041Target: Codable, Equatable {
 
     /// Frequency band in Hz
     public let frequency: Int
 
-    /// Target RT60 value in seconds according to DIN 18041
+    /// Mid-band target RT60 value `T_soll` in seconds.
     public let targetRT60: Double
 
-    /// Tolerance range in seconds (±tolerance)
-    public let tolerance: Double
+    /// Lower bound of the acceptable RT60 range in seconds.
+    public let lowerBound: Double
 
-    /// Initialize a new DIN 18041 target
-    /// - Parameters:
-    ///   - frequency: Frequency band in Hz
-    ///   - targetRT60: Target RT60 value in seconds
-    ///   - tolerance: Tolerance range in seconds
-    public init(frequency: Int, targetRT60: Double, tolerance: Double) {
+    /// Upper bound of the acceptable RT60 range in seconds.
+    public let upperBound: Double
+
+    /// Initialize with explicit bounds in seconds.
+    public init(frequency: Int, targetRT60: Double, lowerBound: Double, upperBound: Double) {
         self.frequency = frequency
         self.targetRT60 = targetRT60
-        self.tolerance = tolerance
+        self.lowerBound = lowerBound
+        self.upperBound = upperBound
     }
 
-    /// Lower bound of acceptable RT60 range
-    public var lowerBound: Double {
-        return targetRT60 - tolerance
+    /// Initialize from tolerance ratios (T / T_soll), as given by Bild 2.
+    public init(frequency: Int, targetRT60: Double, lowerRatio: Double, upperRatio: Double) {
+        self.init(
+            frequency: frequency,
+            targetRT60: targetRT60,
+            lowerBound: targetRT60 * lowerRatio,
+            upperBound: targetRT60 * upperRatio
+        )
     }
 
-    /// Upper bound of acceptable RT60 range
-    public var upperBound: Double {
-        return targetRT60 + tolerance
-    }
-
-    /// Check if a measured RT60 value is within tolerance
-    /// - Parameter measuredRT60: Measured RT60 value in seconds
-    /// - Returns: True if within acceptable range
+    /// Check if a measured RT60 value is within the tolerance band.
     public func isWithinTolerance(_ measuredRT60: Double) -> Bool {
         return measuredRT60 >= lowerBound && measuredRT60 <= upperBound
     }
 
-    /// Evaluate compliance status for a measured value
-    /// - Parameter measuredRT60: Measured RT60 value in seconds
-    /// - Returns: Evaluation status
+    /// Evaluate compliance status for a measured value.
     public func evaluateCompliance(_ measuredRT60: Double) -> EvaluationStatus {
         if measuredRT60 > upperBound {
             return .tooHigh

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Models/RoomType.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Models/RoomType.swift
@@ -1,78 +1,123 @@
 // RoomType.swift
-// Data model for room classification according to DIN 18041
+// Room usage classification according to DIN 18041:2016-03 (Gruppe A).
 
 import Foundation
 
-/// Room type classification according to DIN 18041 standard
+/// Room usage groups of DIN 18041:2016-03, table 5 / equations (1)–(6).
 ///
-/// This enumeration defines the supported room types according to DIN 18041,
-/// which determines the target RT60 values and tolerance ranges for acoustic evaluation.
-/// Each room type has specific requirements based on its intended use.
+/// Each group defines a volume-dependent target reverberation time
+/// `T_soll = a · lg(V) + b` (V in m³, `lg` = log base 10) and a frequency
+/// dependent tolerance band (Bild 2). The previous, invented room types
+/// (classroom/office/…) did not correspond to the standard and were replaced
+/// by the normative groups A1–A5.
 public enum RoomType: String, CaseIterable, Codable {
 
-    /// Classroom or teaching room
-    case classroom = "classroom"
+    /// A1 – Music
+    case a1Music = "A1"
 
-    /// Office space for speech communication
-    case officeSpace = "office_space"
+    /// A2 – Speech/lecture
+    case a2Speech = "A2"
 
-    /// Conference room for meetings and presentations
-    case conference = "conference"
+    /// A3 – Teaching/communication
+    case a3Education = "A3"
 
-    /// Lecture hall or auditorium
-    case lecture = "lecture"
+    /// A4 – Teaching/communication, inclusive
+    case a4EducationInclusive = "A4"
 
-    /// Music room or rehearsal space
-    case music = "music"
+    /// A5 – Sport
+    case a5Sports = "A5"
 
-    /// Sports hall or gymnasium
-    case sports = "sports"
+    /// Group label as used by the standard ("A1" … "A5").
+    public var groupLabel: String { rawValue }
 
-    /// Human-readable display name in German
+    /// Human-readable display name (German).
     public var displayName: String {
         switch self {
-        case .classroom:
-            return "Klassenzimmer"
-        case .officeSpace:
-            return "Büroraum"
-        case .conference:
-            return "Konferenzraum"
-        case .lecture:
-            return "Hörsaal"
-        case .music:
-            return "Musikraum"
-        case .sports:
-            return "Sporthalle"
+        case .a1Music:
+            return "A1 – Musik"
+        case .a2Speech:
+            return "A2 – Sprache/Vortrag"
+        case .a3Education:
+            return "A3 – Unterricht/Kommunikation"
+        case .a4EducationInclusive:
+            return "A4 – Unterricht/Kommunikation inklusiv"
+        case .a5Sports:
+            return "A5 – Sport"
         }
     }
 
-    /// Primary use category for acoustic planning
-    public var primaryUse: String {
+    /// Volume range [m³] for which the target equation is defined
+    /// (DIN 18041:2016-03, table 5).
+    public var validVolumeRange: ClosedRange<Double> {
         switch self {
-        case .classroom, .officeSpace, .conference, .lecture:
-            return "Speech"
-        case .music:
-            return "Music"
-        case .sports:
-            return "Sports"
+        case .a1Music:
+            return 30...1000
+        case .a2Speech:
+            return 50...5000
+        case .a3Education:
+            return 30...5000
+        case .a4EducationInclusive:
+            return 30...500
+        case .a5Sports:
+            return 200...10000
         }
     }
 
-    /// Typical volume range for this room type (in cubic meters)
-    public var typicalVolumeRange: ClosedRange<Double> {
+    /// Whether the given room volume lies within this group's validity range.
+    public func isVolumeWithinValidRange(_ volume: Double) -> Bool {
+        validVolumeRange.contains(volume)
+    }
+
+    /// Mid-band target reverberation time `T_soll` [s] for the given volume.
+    ///
+    /// `T_soll = a · lg(V) + b` per DIN 18041:2016-03, equations (1)–(6).
+    /// For A5 the value is capped at 2.0 s from 10 000 m³ upwards (the equation
+    /// already yields 2.0 s at 10 000 m³).
+    public func targetReverberationTime(volume: Double) -> Double {
+        let lg = log10(max(volume, 1.0))
         switch self {
-        case .classroom:
-            return 120...300
-        case .officeSpace:
-            return 30...150
-        case .conference:
-            return 50...200
-        case .lecture:
-            return 300...2000
-        case .music:
-            return 150...1000
-        case .sports:
-            return 1000...10000
+        case .a1Music:
+            return 0.45 * lg + 0.07
+        case .a2Speech:
+            return 0.37 * lg - 0.14
+        case .a3Education:
+            return 0.32 * lg - 0.17
+        case .a4EducationInclusive:
+            return 0.26 * lg - 0.14
+        case .a5Sports:
+            return min(0.75 * lg - 1.00, 2.0)
+        }
+    }
+
+    /// Octave-band centre frequencies [Hz] at which compliance is verified.
+    ///
+    /// A1–A4 are evaluated across 125–4000 Hz; A5 is only specified for
+    /// 250–2000 Hz (DIN 18041:2016-03, Bild 2 / 5.2).
+    public var evaluationFrequencies: [Int] {
+        switch self {
+        case .a5Sports:
+            return [250, 500, 1000, 2000]
+        default:
+            return [125, 250, 500, 1000, 2000, 4000]
+        }
+    }
+
+    /// Tolerance band as ratio `T / T_soll` (lower, upper) for the given octave,
+    /// per DIN 18041:2016-03, Bild 2.
+    ///
+    /// - A1–A4: 0.80–1.20 in the mid band, widening to 0.65–1.45 at the
+    ///   125 Hz and 4000 Hz edges.
+    /// - A5: ±20 % (0.80–1.20) across the specified 250–2000 Hz range.
+    public func toleranceRatios(at frequency: Int) -> (lower: Double, upper: Double) {
+        switch self {
+        case .a5Sports:
+            return (0.80, 1.20)
+        default:
+            if frequency <= 125 || frequency >= 4000 {
+                return (0.65, 1.45)
+            } else {
+                return (0.80, 1.20)
+            }
         }
     }
 }

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
@@ -54,10 +54,12 @@ extension ReportModel {
         let dinTargets = DIN18041Database.targets(for: reportData.roomType, volume: reportData.volume)
 
         let din_targets = reportData.dinResults.map { deviation -> [String: Double] in
-            // Look up the actual tolerance from DIN database for this frequency
+            // The Bild 2 tolerance band is asymmetric (lower/upper bounds in
+            // seconds); expose half the band width as a representative ± value
+            // for the report's "tol" field.
             let actualTolerance = dinTargets
-                .first { $0.frequency == deviation.frequency }?
-                .tolerance ?? 0.1 // Fallback to 0.1s if not found
+                .first { $0.frequency == deviation.frequency }
+                .map { ($0.upperBound - $0.lowerBound) / 2.0 } ?? 0.1
 
             return [
                 "freq_hz": Double(deviation.frequency),

--- a/AcoustiScanConsolidated/Sources/AcoustiScanTool/SampleData.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanTool/SampleData.swift
@@ -22,7 +22,7 @@ struct SampleDataset {
 enum SampleData {
     static func baselineDataset() -> SampleDataset {
         let configuration = SampleRoomConfiguration(
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0,
             surfaces: [
                 AcousticSurface(

--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
@@ -70,7 +70,7 @@ final class RT60CalculatorTests: XCTestCase {
 
         let deviations = RT60Calculator.evaluateDINCompliance(
             measurements: measurements,
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0
         )
 
@@ -83,15 +83,16 @@ final class RT60CalculatorTests: XCTestCase {
 
 final class DIN18041Tests: XCTestCase {
 
-    func testClassroomTargetsProvideSevenBands() {
-        let targets = DIN18041Database.targets(for: .classroom, volume: 200.0)
+    func testA3EducationTargetsCoverSixOctaveBands() {
+        let targets = DIN18041Database.targets(for: .a3Education, volume: 200.0)
 
-        XCTAssertEqual(targets.count, 7)
+        // A1–A4 are verified across 125–4000 Hz (six octave bands).
+        XCTAssertEqual(targets.count, 6)
         XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 0 })
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance > 0 })
+        XCTAssertTrue(targets.allSatisfy { $0.upperBound > $0.lowerBound })
 
-        let midFreqTargets = targets.filter { $0.frequency == 500 || $0.frequency == 1000 }
-        XCTAssertTrue(midFreqTargets.allSatisfy { $0.targetRT60 <= 0.8 })
+        // T_soll(A3, 200 m³) = 0.32·lg(200) − 0.17 ≈ 0.566 s, equal across bands.
+        XCTAssertEqual(targets.first?.targetRT60 ?? 0, 0.566, accuracy: 0.01)
     }
 
     func testDINComplianceEvaluationProducesDeviations() {
@@ -103,7 +104,7 @@ final class DIN18041Tests: XCTestCase {
 
         let deviations = RT60Calculator.evaluateDINCompliance(
             measurements: measurements,
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0
         )
 
@@ -280,7 +281,7 @@ final class PDFExportTests: XCTestCase {
     func testReportDataStructure() {
         let reportData = ConsolidatedPDFExporter.ReportData(
             date: "2025-01-01",
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0,
             rt60Measurements: [
                 RT60Measurement(frequency: 1000, rt60: 0.6)
@@ -297,7 +298,7 @@ final class PDFExportTests: XCTestCase {
         )
 
         XCTAssertEqual(reportData.date, "2025-01-01")
-        XCTAssertEqual(reportData.roomType, .classroom)
+        XCTAssertEqual(reportData.roomType, .a3Education)
         XCTAssertEqual(reportData.volume, 150.0)
         XCTAssertEqual(reportData.rt60Measurements.count, 1)
         XCTAssertEqual(reportData.dinResults.count, 1)

--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/DIN18041Tests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/DIN18041Tests.swift
@@ -1,340 +1,180 @@
 // DIN18041Tests.swift
-// Comprehensive test suite for DIN 18041 module
+// Test suite for the DIN 18041:2016-03 compliance module (Gruppe A).
 
 import XCTest
 import Foundation
 @testable import AcoustiScanConsolidated
 
-/// Comprehensive test suite for DIN 18041 compliance evaluation
+/// Tests for the normative DIN 18041:2016-03 target and tolerance logic.
 final class DIN18041ModuleTests: XCTestCase {
 
-    // MARK: - DIN18041Database Tests
+    // MARK: - Target reverberation time T_soll = a·lg(V) + b
 
-    func testClassroomTargets() {
+    func testTargetReverberationTimeFormulasPerGroup() {
+        // A1 Musik: 0.45·lg(V) + 0.07
+        XCTAssertEqual(RoomType.a1Music.targetReverberationTime(volume: 500), 1.285, accuracy: 0.005)
+        // A2 Sprache/Vortrag: 0.37·lg(V) − 0.14
+        XCTAssertEqual(RoomType.a2Speech.targetReverberationTime(volume: 1000), 0.97, accuracy: 0.005)
+        // A3 Unterricht/Kommunikation: 0.32·lg(V) − 0.17
+        XCTAssertEqual(RoomType.a3Education.targetReverberationTime(volume: 200), 0.566, accuracy: 0.005)
+        // A4 Unterricht inklusiv: 0.26·lg(V) − 0.14
+        XCTAssertEqual(RoomType.a4EducationInclusive.targetReverberationTime(volume: 100), 0.38, accuracy: 0.005)
+        // A5 Sport: 0.75·lg(V) − 1.00
+        XCTAssertEqual(RoomType.a5Sports.targetReverberationTime(volume: 2000), 1.476, accuracy: 0.005)
+    }
+
+    func testA5IsCappedAtTwoSecondsFromTenThousandCubicMetres() {
+        // The equation already yields 2.0 s at 10 000 m³ and is capped beyond.
+        XCTAssertEqual(RoomType.a5Sports.targetReverberationTime(volume: 10_000), 2.0, accuracy: 0.005)
+        XCTAssertEqual(RoomType.a5Sports.targetReverberationTime(volume: 20_000), 2.0, accuracy: 0.005)
+    }
+
+    func testValidVolumeRanges() {
+        XCTAssertEqual(RoomType.a1Music.validVolumeRange, 30...1000)
+        XCTAssertEqual(RoomType.a2Speech.validVolumeRange, 50...5000)
+        XCTAssertEqual(RoomType.a3Education.validVolumeRange, 30...5000)
+        XCTAssertEqual(RoomType.a4EducationInclusive.validVolumeRange, 30...500)
+        XCTAssertEqual(RoomType.a5Sports.validVolumeRange, 200...10000)
+        XCTAssertFalse(RoomType.a4EducationInclusive.isVolumeWithinValidRange(600))
+        XCTAssertTrue(RoomType.a4EducationInclusive.isVolumeWithinValidRange(300))
+    }
+
+    // MARK: - Evaluated octave bands
+
+    func testA1ToA4AreEvaluatedAcross125To4000Hz() {
+        for group in [RoomType.a1Music, .a2Speech, .a3Education, .a4EducationInclusive] {
+            let targets = DIN18041Database.targets(for: group, volume: 200.0)
+            XCTAssertEqual(targets.map { $0.frequency }.sorted(), [125, 250, 500, 1000, 2000, 4000])
+        }
+    }
+
+    func testA5IsOnlyEvaluatedAcross250To2000Hz() {
+        let targets = DIN18041Database.targets(for: .a5Sports, volume: 2000.0)
+        XCTAssertEqual(targets.map { $0.frequency }.sorted(), [250, 500, 1000, 2000])
+    }
+
+    // MARK: - Bild 2 tolerance band
+
+    func testToleranceBandMidVersusEdgesForA1ToA4() {
         let volume = 200.0
-        let targets = DIN18041Database.targets(for: .classroom, volume: volume)
+        let tSoll = RoomType.a3Education.targetReverberationTime(volume: volume)
+        let targets = DIN18041Database.targets(for: .a3Education, volume: volume)
 
-        XCTAssertEqual(targets.count, 7) // 7 frequency bands
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 0 })
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance > 0 })
-
-        // Check that 500-1000 Hz has reasonable values for classroom
-        let midFreqTargets = targets.filter { $0.frequency == 500 || $0.frequency == 1000 }
-        XCTAssertTrue(midFreqTargets.allSatisfy { $0.targetRT60 <= 0.8 }) // Should be relatively low for speech
-
-        // Verify frequency-dependent adjustments
-        guard let lowFreq = targets.first(where: { $0.frequency == 125 }) else {
-            XCTFail("Expected to find 125 Hz target")
-            return
-        }
-        guard let midFreq = targets.first(where: { $0.frequency == 1000 }) else {
-            XCTFail("Expected to find 1000 Hz target")
-            return
-        }
-        guard let highFreq = targets.first(where: { $0.frequency == 4000 }) else {
-            XCTFail("Expected to find 4000 Hz target")
-            return
+        guard let mid = targets.first(where: { $0.frequency == 500 }),
+              let edge = targets.first(where: { $0.frequency == 125 }) else {
+            return XCTFail("Expected 500 Hz and 125 Hz targets")
         }
 
-        XCTAssertTrue(lowFreq.targetRT60 > midFreq.targetRT60) // Low frequencies should have higher RT60
-        XCTAssertTrue(highFreq.targetRT60 < midFreq.targetRT60) // High frequencies should have lower RT60
+        // Mid band: 0.80–1.20 · T_soll
+        XCTAssertEqual(mid.lowerBound, tSoll * 0.80, accuracy: 0.001)
+        XCTAssertEqual(mid.upperBound, tSoll * 1.20, accuracy: 0.001)
+        // Edge band (125 Hz): 0.65–1.45 · T_soll
+        XCTAssertEqual(edge.lowerBound, tSoll * 0.65, accuracy: 0.001)
+        XCTAssertEqual(edge.upperBound, tSoll * 1.45, accuracy: 0.001)
     }
 
-    func testOfficeSpaceTargets() {
-        let volume = 120.0
-        let targets = DIN18041Database.targets(for: .officeSpace, volume: volume)
-
-        XCTAssertEqual(targets.count, 7)
-        // Office spaces should have low RT60 values around 0.5s (volume-adjusted)
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 0 })
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 < 0.7 }) // Should be relatively low
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance == 0.1 })
-
-        // Speech frequencies (500-2000 Hz) should have slightly lower RT60
-        let speechFreqTargets = targets.filter { $0.frequency >= 500 && $0.frequency <= 2000 }
-        let otherFreqTargets = targets.filter { $0.frequency < 500 || $0.frequency > 2000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for speech in speechFreqTargets {
-            for other in otherFreqTargets {
-                XCTAssertLessThanOrEqual(speech.targetRT60, other.targetRT60,
-                    "Speech frequency \(speech.frequency) Hz (\(speech.targetRT60)) should be <= other frequency \(other.frequency) Hz (\(other.targetRT60))")
-            }
-        }
-    }
-
-    func testConferenceRoomTargets() {
-        let volume = 300.0
-        let targets = DIN18041Database.targets(for: .conference, volume: volume)
-
-        XCTAssertEqual(targets.count, 7)
-        // Conference rooms have volume-adjusted RT60 around 0.7-0.8 range
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 0.65 && $0.targetRT60 < 0.85 })
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance == 0.15 })
-
-        // Speech frequencies (500-4000 Hz) should have optimized (lower) RT60
-        let speechFreqTargets = targets.filter { $0.frequency >= 500 && $0.frequency <= 4000 }
-        let lowFreqTargets = targets.filter { $0.frequency < 500 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for speech in speechFreqTargets {
-            for low in lowFreqTargets {
-                XCTAssertLessThan(speech.targetRT60, low.targetRT60,
-                    "Speech frequency \(speech.frequency) Hz (\(speech.targetRT60)) should be < low frequency \(low.frequency) Hz (\(low.targetRT60))")
-            }
-        }
-    }
-
-    func testLectureHallTargets() {
-        let volume = 500.0
-        let targets = DIN18041Database.targets(for: .lecture, volume: volume)
-
-        XCTAssertEqual(targets.count, 7)
-        // Lecture halls have volume-adjusted RT60 with higher volume scaling
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 0.7 && $0.targetRT60 < 1.2 })
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance == 0.15 })
-
-        // Low frequencies (≤250 Hz) should have higher RT60 for warmth
-        let lowFreqTargets = targets.filter { $0.frequency <= 250 }
-        let midFreqTargets = targets.filter { $0.frequency > 250 && $0.frequency < 4000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for low in lowFreqTargets {
-            for mid in midFreqTargets {
-                XCTAssertGreaterThan(low.targetRT60, mid.targetRT60,
-                    "Low frequency \(low.frequency) Hz (\(low.targetRT60)) should be > mid frequency \(mid.frequency) Hz (\(mid.targetRT60))")
-            }
-        }
-
-        // High frequencies (≥4000 Hz) should have lower RT60 for clarity
-        let highFreqTargets = targets.filter { $0.frequency >= 4000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for high in highFreqTargets {
-            for mid in midFreqTargets {
-                XCTAssertLessThan(high.targetRT60, mid.targetRT60,
-                    "High frequency \(high.frequency) Hz (\(high.targetRT60)) should be < mid frequency \(mid.frequency) Hz (\(mid.targetRT60))")
-            }
-        }
-    }
-
-    func testMusicRoomTargets() {
-        let volume = 400.0
-        let targets = DIN18041Database.targets(for: .music, volume: volume)
-
-        XCTAssertEqual(targets.count, 7)
-        // Music rooms need longer reverberation around 1.5s (volume-adjusted with frequency variation)
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 1.0 })
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 < 2.5 }) // Should be higher for music
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance == 0.2 })
-
-        // Low frequencies (125 Hz) should have fuller bass response
-        guard let lowFreqTarget = targets.first(where: { $0.frequency == 125 }) else {
-            XCTFail("Expected to find 125 Hz target")
-            return
-        }
-        let midFreqTargets = targets.filter { $0.frequency > 125 && $0.frequency < 4000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for mid in midFreqTargets {
-            XCTAssertGreaterThan(lowFreqTarget.targetRT60, mid.targetRT60,
-                "Low frequency 125 Hz (\(lowFreqTarget.targetRT60)) should be > mid frequency \(mid.frequency) Hz (\(mid.targetRT60))")
-        }
-
-        // High frequencies (≥4000 Hz) should have controlled brilliance
-        let highFreqTargets = targets.filter { $0.frequency >= 4000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for high in highFreqTargets {
-            for mid in midFreqTargets {
-                XCTAssertLessThan(high.targetRT60, mid.targetRT60,
-                    "High frequency \(high.frequency) Hz (\(high.targetRT60)) should be < mid frequency \(mid.frequency) Hz (\(mid.targetRT60))")
-            }
-        }
-    }
-
-    func testSportsHallTargets() {
+    func testToleranceBandForA5IsPlusMinusTwentyPercent() {
         let volume = 2000.0
-        let targets = DIN18041Database.targets(for: .sports, volume: volume)
+        let tSoll = RoomType.a5Sports.targetReverberationTime(volume: volume)
+        let targets = DIN18041Database.targets(for: .a5Sports, volume: volume)
 
-        XCTAssertEqual(targets.count, 7)
-        // Sports halls can have highest RT60 around 2.0s (volume-adjusted with frequency variation)
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 > 1.5 })
-        XCTAssertTrue(targets.allSatisfy { $0.targetRT60 < 3.0 }) // Should be highest
-        XCTAssertTrue(targets.allSatisfy { $0.tolerance == 0.3 })
-
-        // Speech/PA frequencies (500-2000 Hz) should have better clarity
-        let paFreqTargets = targets.filter { $0.frequency >= 500 && $0.frequency <= 2000 }
-        let otherFreqTargets = targets.filter { $0.frequency < 500 || $0.frequency > 2000 }
-
-        // More explicit check to avoid nested allSatisfy issues on some platforms
-        for pa in paFreqTargets {
-            for other in otherFreqTargets {
-                XCTAssertLessThanOrEqual(pa.targetRT60, other.targetRT60,
-                    "PA frequency \(pa.frequency) Hz (\(pa.targetRT60)) should be <= other frequency \(other.frequency) Hz (\(other.targetRT60))")
-            }
+        for target in targets {
+            XCTAssertEqual(target.lowerBound, tSoll * 0.80, accuracy: 0.001)
+            XCTAssertEqual(target.upperBound, tSoll * 1.20, accuracy: 0.001)
         }
     }
 
-    func testFrequencyCoverage() {
-        let expectedFrequencies = [125, 250, 500, 1000, 2000, 4000, 8000]
+    // MARK: - Compliance evaluation
 
-        for roomType in RoomType.allCases {
-            let targets = DIN18041Database.targets(for: roomType, volume: 300.0)
-            let frequencies = targets.map { $0.frequency }.sorted()
-            XCTAssertEqual(frequencies, expectedFrequencies, "Room type \(roomType) missing frequencies")
-        }
-    }
-
-    // MARK: - RT60Evaluator Tests
-
-    func testCompliantEvaluation() {
-        let measurements = [
-            RT60Measurement(frequency: 500, rt60: 0.60),
-            RT60Measurement(frequency: 1000, rt60: 0.55),
-            RT60Measurement(frequency: 2000, rt60: 0.52)
-        ]
+    func testMeasurementsAtTargetAreWithinTolerance() {
+        let targets = DIN18041Database.targets(for: .a3Education, volume: 150.0)
+        let measurements = targets.map { RT60Measurement(frequency: $0.frequency, rt60: $0.targetRT60) }
 
         let deviations = RT60Evaluator.evaluateDINCompliance(
             measurements: measurements,
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0
         )
 
-        XCTAssertEqual(deviations.count, 3)
+        XCTAssertEqual(deviations.count, targets.count)
         XCTAssertTrue(deviations.allSatisfy { $0.status == .withinTolerance })
-        XCTAssertTrue(deviations.allSatisfy { abs($0.deviation) <= 0.1 })
+        XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: deviations), .withinTolerance)
     }
 
-    func testTooHighEvaluation() {
-        let measurements = [
-            RT60Measurement(frequency: 500, rt60: 0.80), // Target ~0.6, tolerance 0.1
-            RT60Measurement(frequency: 1000, rt60: 0.75),
-            RT60Measurement(frequency: 2000, rt60: 0.70)
-        ]
-
-        let deviations = RT60Evaluator.evaluateDINCompliance(
-            measurements: measurements,
-            roomType: .classroom,
+    func testTooHighAndTooLowAtMidBand() {
+        // A3 at 150 m³: T_soll ≈ 0.526 s; mid band 500 Hz tolerance ≈ [0.421, 0.632].
+        let tooHigh = RT60Evaluator.evaluateDINCompliance(
+            measurements: [RT60Measurement(frequency: 500, rt60: 0.80)],
+            roomType: .a3Education,
             volume: 150.0
         )
+        XCTAssertEqual(tooHigh.first?.status, .tooHigh)
 
-        XCTAssertEqual(deviations.count, 3)
-        XCTAssertTrue(deviations.allSatisfy { $0.status == .tooHigh })
-        XCTAssertTrue(deviations.allSatisfy { $0.deviation > 0.1 })
-    }
-
-    func testTooLowEvaluation() {
-        let measurements = [
-            RT60Measurement(frequency: 500, rt60: 0.40), // Target ~0.6, tolerance 0.1
-            RT60Measurement(frequency: 1000, rt60: 0.35),
-            RT60Measurement(frequency: 2000, rt60: 0.30)
-        ]
-
-        let deviations = RT60Evaluator.evaluateDINCompliance(
-            measurements: measurements,
-            roomType: .classroom,
+        let tooLow = RT60Evaluator.evaluateDINCompliance(
+            measurements: [RT60Measurement(frequency: 500, rt60: 0.30)],
+            roomType: .a3Education,
             volume: 150.0
         )
-
-        XCTAssertEqual(deviations.count, 3)
-        XCTAssertTrue(deviations.allSatisfy { $0.status == .tooLow })
-        XCTAssertTrue(deviations.allSatisfy { $0.deviation < -0.1 })
+        XCTAssertEqual(tooLow.first?.status, .tooLow)
     }
 
-    func testRT60Classification() {
-        let target = 0.6
-        let tolerance = 0.1
-
-        // Within tolerance
-        XCTAssertEqual(RT60Evaluator.classifyRT60(measured: 0.60, target: target, tolerance: tolerance), .withinTolerance)
-        XCTAssertEqual(RT60Evaluator.classifyRT60(measured: 0.65, target: target, tolerance: tolerance), .withinTolerance)
-        XCTAssertEqual(RT60Evaluator.classifyRT60(measured: 0.55, target: target, tolerance: tolerance), .withinTolerance)
-
-        // Too high
-        XCTAssertEqual(RT60Evaluator.classifyRT60(measured: 0.75, target: target, tolerance: tolerance), .tooHigh)
-
-        // Too low
-        XCTAssertEqual(RT60Evaluator.classifyRT60(measured: 0.45, target: target, tolerance: tolerance), .tooLow)
-    }
-
-    func testOverallCompliance() {
-        // All compliant
-        let allCompliant = [
-            RT60Deviation(frequency: 500, measuredRT60: 0.60, targetRT60: 0.60, status: .withinTolerance),
-            RT60Deviation(frequency: 1000, measuredRT60: 0.55, targetRT60: 0.60, status: .withinTolerance)
+    func testEdgeBandToleratesMoreThanMidBand() {
+        // The same low RT60 that is "too low" at 500 Hz can still be within the
+        // wider 125 Hz edge band, demonstrating the frequency-dependent tolerance.
+        let measurements = [
+            RT60Measurement(frequency: 125, rt60: 0.40),
+            RT60Measurement(frequency: 500, rt60: 0.40)
         ]
-        XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: allCompliant), .withinTolerance)
-
-        // Partially compliant (less than half non-compliant)
-        let partiallyCompliant = [
-            RT60Deviation(frequency: 500, measuredRT60: 0.60, targetRT60: 0.60, status: .withinTolerance),
-            RT60Deviation(frequency: 1000, measuredRT60: 0.80, targetRT60: 0.60, status: .tooHigh),
-            RT60Deviation(frequency: 2000, measuredRT60: 0.55, targetRT60: 0.48, status: .withinTolerance)
-        ]
-        XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: partiallyCompliant), .partiallyCompliant)
-
-        // Non-compliant (more than half non-compliant)
-        let nonCompliant = [
-            RT60Deviation(frequency: 500, measuredRT60: 0.80, targetRT60: 0.60, status: .tooHigh),
-            RT60Deviation(frequency: 1000, measuredRT60: 0.85, targetRT60: 0.60, status: .tooHigh),
-            RT60Deviation(frequency: 2000, measuredRT60: 0.55, targetRT60: 0.48, status: .withinTolerance)
-        ]
-        XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: nonCompliant), .tooHigh)
-    }
-
-    // MARK: - Integration Tests
-
-    func testCompleteWorkflow() {
-        let volumes = [150.0, 300.0, 500.0]
-        let roomTypes: [RoomType] = [.classroom, .officeSpace, .conference, .lecture, .music, .sports]
-
-        for roomType in roomTypes {
-            for volume in volumes {
-                let targets = DIN18041Database.targets(for: roomType, volume: volume)
-
-                // Create test measurements that should be within tolerance
-                let measurements = targets.map { target in
-                    RT60Measurement(frequency: target.frequency, rt60: target.targetRT60)
-                }
-
-                let deviations = RT60Evaluator.evaluateDINCompliance(
-                    measurements: measurements,
-                    roomType: roomType,
-                    volume: volume
-                )
-
-                XCTAssertEqual(deviations.count, targets.count)
-                XCTAssertTrue(deviations.allSatisfy { $0.status == .withinTolerance })
-                XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: deviations), .withinTolerance)
-            }
-        }
+        let deviations = RT60Evaluator.evaluateDINCompliance(
+            measurements: measurements,
+            roomType: .a3Education,
+            volume: 150.0
+        )
+        let edge = deviations.first { $0.frequency == 125 }
+        let mid = deviations.first { $0.frequency == 500 }
+        XCTAssertEqual(edge?.status, .withinTolerance)
+        XCTAssertEqual(mid?.status, .tooLow)
     }
 
     func testEmptyMeasurements() {
         let deviations = RT60Evaluator.evaluateDINCompliance(
             measurements: [],
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0
         )
-
         XCTAssertTrue(deviations.isEmpty)
         XCTAssertEqual(RT60Evaluator.overallCompliance(deviations: []), .withinTolerance)
     }
 
-    func testMismatchedFrequencies() {
+    func testMismatchedFrequenciesAreIgnored() {
         let measurements = [
-            RT60Measurement(frequency: 100, rt60: 0.60), // Non-standard frequency
-            RT60Measurement(frequency: 500, rt60: 0.60),  // Standard frequency
+            RT60Measurement(frequency: 100, rt60: 0.60), // not an evaluated octave
+            RT60Measurement(frequency: 500, rt60: 0.60)
         ]
-
         let deviations = RT60Evaluator.evaluateDINCompliance(
             measurements: measurements,
-            roomType: .classroom,
+            roomType: .a3Education,
             volume: 150.0
         )
-
-        XCTAssertEqual(deviations.count, 1) // Only the 500 Hz measurement should be evaluated
+        XCTAssertEqual(deviations.count, 1)
         XCTAssertEqual(deviations.first?.frequency, 500)
+    }
+
+    func testCompleteWorkflowForEveryGroup() {
+        for group in RoomType.allCases {
+            let range = group.validVolumeRange
+            let volume = (range.lowerBound + range.upperBound) / 2.0
+            let targets = DIN18041Database.targets(for: group, volume: volume)
+            let measurements = targets.map { RT60Measurement(frequency: $0.frequency, rt60: $0.targetRT60) }
+
+            let deviations = RT60Evaluator.evaluateDINCompliance(
+                measurements: measurements,
+                roomType: group,
+                volume: volume
+            )
+
+            XCTAssertEqual(deviations.count, targets.count, "\(group) band count")
+            XCTAssertTrue(deviations.allSatisfy { $0.status == .withinTolerance }, "\(group) all within tolerance")
+        }
     }
 }


### PR DESCRIPTION
## Ziel
Die DIN-18041-Auswertung **normtreu** machen. Bisher basierte sie auf einer **frei erfundenen** Formel `T_soll = T_base·(V/V_ref)^exp` mit ausgedachten Basiswerten/Exponenten/Toleranzen und erfundenen Raumtypen (classroom/office/…), die nicht der Norm entsprachen.

## Änderung (nach DIN 18041:2016-03, Gruppe A)
- **`RoomType` → Nutzungsarten A1–A5** mit den echten Sollwertgleichungen `T_soll = a·lg(V) + b` (Gl. (1)–(6)), Gültigkeitsbereichen und A5-Deckelung auf 2,0 s ab 10 000 m³.

| Gruppe | `T_soll` [s] | Bereich |
|--------|--------------|---------|
| A1 Musik | `0,45·lg(V)+0,07` | 30–1000 |
| A2 Sprache/Vortrag | `0,37·lg(V)−0,14` | 50–5000 |
| A3 Unterricht/Kommunikation | `0,32·lg(V)−0,17` | 30–5000 |
| A4 Unterricht inklusiv | `0,26·lg(V)−0,14` | 30–500 |
| A5 Sport | `0,75·lg(V)−1,00` (cap 2,0) | 200–10000 |

- **`DIN18041Target`**: asymmetrisches Toleranzband (untere/obere Grenze in Sekunden) statt symmetrischem `±s`, weil Bild 2 asymmetrisch ist.
- **`DIN18041Database`**: baut je Oktave `T_soll × Bild-2-Verhältnis` (0,80–1,20 Mittenband; 0,65–1,45 an den Rändern 125/4000 Hz; A5 ±20 % nur 250–2000 Hz).
- **`RT60Evaluator`**: Klassifikation delegiert an die Band-Grenzen des Targets.
- **Tests neu**: prüfen die normativen Formeln (exakte Werte), Bandanzahl (A1–A4: 6 Oktaven; A5: 4), das Toleranzband (Mitte vs. Rand) und den A5-Sonderfall. Sample-/Report-Fixtures auf A3 gemappt.

Werte gemäß der in der README (#248) dokumentierten, von dir bereitgestellten DIN-18041:2016-03-Grundlage.

## Scope
Begrenzt auf das Package `AcoustiScanConsolidated` (RoomType wird im App-Code nicht verwendet). Verifikation durch die ehrliche CI (Packages-Tests + iOS-App-Build).

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_