### PR TITLE
Cleanup + Doku: ungenutzte ReportExport-Dependency, Node-Warnung, Tech-Debt dokumentiert

### DIFF
--- a/.github/workflows/ci-honest.yml
+++ b/.github/workflows/ci-honest.yml
@@ -34,6 +34,8 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
+          # Pinned for reproducible builds (ships the iOS 17 SDK). Bump
+          # deliberately once validated on a newer Xcode.
           xcode-version: '15.4'
 
       - name: Toolchain versions
@@ -55,7 +57,7 @@ jobs:
 
       - name: Report failure to PR
         if: failure() && github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -84,6 +86,8 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
+          # Pinned for reproducible builds (ships the iOS 17 SDK). Bump
+          # deliberately once validated on a newer Xcode.
           xcode-version: '15.4'
 
       - name: Toolchain + scheme listing
@@ -105,7 +109,7 @@ jobs:
 
       - name: Report failure to PR
         if: failure() && github.event_name == 'push'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/AcoustiScanApp/Package.swift
+++ b/AcoustiScanApp/Package.swift
@@ -14,15 +14,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: "../AcoustiScanConsolidated"),
-        .package(name: "ReportExport", path: "../Modules/Export")
+        .package(path: "../AcoustiScanConsolidated")
     ],
     targets: [
         .target(
             name: "AcoustiScanApp",
             dependencies: [
-                .product(name: "AcoustiScanConsolidated", package: "AcoustiScanConsolidated"),
-                .product(name: "ReportExport", package: "ReportExport")
+                .product(name: "AcoustiScanConsolidated", package: "AcoustiScanConsolidated")
             ],
             path: "AcoustiScanApp",
             swiftSettings: [

--- a/README.md
+++ b/README.md
@@ -444,18 +444,34 @@ Proprietary - Alle Rechte vorbehalten
 
 - **Berechnungskern (`AcoustiScanConsolidated`, `Modules/Export`)**: solide, getestet,
   baut plattformunabhängig via `swift build`/`swift test`. **Übernahmefähig.**
-- **iOS-App (`AcoustiScanApp`)**: **noch nicht produktionsreif.** Der App-Einstieg
-  (`ContentView`) ist aktuell ein Platzhalter; die unten beschriebene 5-Tab-Navigation
-  ist noch nicht verdrahtet. Einzelne Views werden gerade integriert/repariert.
-- **CI**: Bis vor Kurzem hat kein Workflow die App per `xcodebuild` gebaut und das
-  App-Test-Target ist nicht im Xcode-Projekt verdrahtet. Der neue Workflow
-  `ci-honest.yml` baut App + Packages ohne Fehler-Maskierung und bildet den
-  wahren Zustand ab.
-- **DIN 18041**: Sollwerte werden auf die normkonformen Gleichungen (1)–(6) nach
-  DIN 18041:2016-03 umgestellt (siehe Sollwert-Tabelle oben).
+- **iOS-App (`AcoustiScanApp`)**: kompiliert **verifiziert** (CI via `xcodebuild` für
+  den iOS-Simulator); der App-Einstieg (`ContentView`) ist als 5-Tab-Navigation
+  (RT60 / Scan / Maße / Material / Export) verdrahtet. Laufzeit-Funktionen auf echtem
+  Gerät (LiDAR/RoomPlan) lassen sich in CI nicht abschließend verifizieren.
+- **CI**: `ci-honest.yml` baut App + Packages ohne Fehler-Maskierung (Xcode 15.4,
+  bewusst gepinnt) und postet bei Fehlern den echten Build-/Test-Tail an den PR. Die
+  früheren maskierenden Workflows (Retry/Self-Healing/Autofix, `swift.yml`,
+  `build-test.yml`) sind stillgelegt.
+- **DIN 18041**: Die normkonformen Sollwertgleichungen (1)–(6) nach DIN 18041:2016-03
+  und das frequenzabhängige Bild-2-Toleranzband (A1–A5) sind implementiert und
+  getestet (siehe Sollwert-Tabelle oben).
 
-Die folgenden Feature-Beschreibungen sind als **Zielbild** zu lesen, nicht als
-fertiger Auslieferungsstand.
+### Bekannte technische Schulden (bewusst zurückgestellt)
+
+- **Doppelte Datenmodelle**: Die App führt eigene Modelle (`AcousticMaterial`,
+  `SurfaceStore`, PDF/XLSX-Exporter) **parallel** zu denen im Package
+  `AcoustiScanConsolidated`. Beide Seiten sind in sich konsistent und grün; eine
+  Konsolidierung (App → Package-Modelle) ist ein größerer, regressionsanfälliger
+  Refactor und wurde bewusst zurückgestellt.
+- **Dual-Build-System der App**: Die CI baut die App über
+  `AcoustiScanApp/AcoustiScanApp.xcodeproj` (xcodebuild). Daneben existiert ein
+  paralleles SPM-Manifest `AcoustiScanApp/Package.swift`, das **nicht** von der CI
+  genutzt wird — bei Build-Einstellungen/Abhängigkeiten ist das **`.xcodeproj`
+  maßgeblich**.
+
+Die folgenden Feature-Beschreibungen sind als **Zielbild** zu lesen: Auf
+Kompilier-/Testebene verifiziert, die volle Geräte-Laufzeit ist noch nicht
+abschließend abgenommen.
 
 ---
 


### PR DESCRIPTION
## Ziel
Letztes Plan-Item: risikoarme Aufräumarbeiten + ehrliche Dokumentation der verbleibenden Tech-Debt (gemäß Entscheidung „Safe-Cleanups + Doku").

## Änderungen
1. **Ungenutzte `ReportExport`-Dependency entfernt** aus `AcoustiScanApp/Package.swift` — keine App-Quelle importiert `ReportExport` (nur die Tests des Export-Moduls selbst), und die CI baut die App ohnehin über das `.xcodeproj`. Toter Ballast.
2. **`actions/github-script@v7 → v8`** in `ci-honest.yml` — beseitigt die Node.js-20-Deprecation-Warnung. Außerdem kurzer Kommentar, warum die Xcode-Version gepinnt ist.
3. **README aktualisiert**:
   - Handoff-Status auf den realen Stand gebracht (ContentView ist jetzt eine echte TabView; DIN-Engine ist normtreu).
   - Neue Sektion **„Bekannte technische Schulden"**: dokumentiert die doppelten Datenmodelle (App vs. Package) und das Dual-Build-System (`.xcodeproj` ist maßgeblich; das parallele `Package.swift` wird von der CI nicht genutzt) — bewusst zurückgestellt statt riskant refactored.

## Risiko
Sehr gering: keine Logikänderung. Die `ReportExport`-Entfernung betrifft nur das von der CI ungenutzte App-Manifest. Verifikation durch `ci-honest.yml`.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_