### PR TITLE
CONTRIBUTING: echte CI (ci-honest.yml) statt stillgelegter Workflows, Struktur korrigiert

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,9 +118,9 @@ RT60_ipad_akusti-scan-APP/
 │   ├── Sources/
 │   │   └── AcoustiScanConsolidated/
 │   │       ├── RT60Calculator.swift    # Sabine-Formel
-│   │       ├── RT60Evaluator.swift     # DIN 18041 Bewertung
-│   │       ├── MaterialDatabase.swift  # 500+ Materialien
-│   │       └── AcousticFramework.swift # 48 Akustik-Parameter
+│   │       ├── DIN18041/               # DIN 18041 Evaluator (A1–A5)
+│   │       ├── Models/                 # RoomType, AcousticMaterial, …
+│   │       └── AcousticFramework.swift # Akustik-Parameter-Katalog
 │   └── Tests/                     # Unit Tests
 │
 ├── Modules/Export/                 # Separates Export-Modul
@@ -128,9 +128,9 @@ RT60_ipad_akusti-scan-APP/
 │   └── Tests/                     # Export-Tests
 │
 └── .github/workflows/             # CI/CD Pipelines
-    ├── build-test.yml             # Haupt-Build
-    ├── swift.yml                  # Swift Tests
-    └── self-healing.yml           # Auto-Fix
+    ├── ci-honest.yml              # AKTIVE CI: App (xcodebuild) + alle Packages
+    └── (build-test.yml, swift.yml,
+         self-healing.yml, …)      # stillgelegt (nur workflow_dispatch)
 ```
 
 ### Architektur-Muster
@@ -338,8 +338,7 @@ Dann auf GitHub:
 - Minderung/Abfang (Fallback, Feature-Flag, Tests, Monitoring) ist beschrieben.
 
 ### Required Checks (müssen grün sein)
-- CI-Workflow **build-test.yml** erfolgreich.
-- CI-Workflow **swift.yml** erfolgreich.
+- CI-Workflow **ci-honest.yml** erfolgreich (baut die App via `xcodebuild` und alle Swift-Packages ohne Fehler-Maskierung).
 - Linting/Formatting (SwiftLint/SwiftFormat) ohne Fehler.
 - Relevante Unit/Integration/UI-Tests vorhanden und grün.
 
@@ -393,7 +392,7 @@ swift test
 swift test -v
 
 # Einzelnen Test ausführen
-swift test --filter RT60CalculatorTests.testSabineFormula
+swift test --filter RT60CalculatorTests.testRT60CalculationUsingSabineFormula
 
 # In Xcode
 # ⌘U = Alle Tests
@@ -563,7 +562,7 @@ swift test
 - [ ] **Business Value** ist klar beschrieben und nachvollziehbar.
 - [ ] **Keine neue technische Schuld** (keine neuen TODOs ohne Ticket, keine Code-Smells).
 - [ ] **Risikoabschätzung** ist dokumentiert inkl. Mitigation.
-- [ ] **Required Checks** sind grün (build-test.yml, swift.yml, Linting, relevante Tests).
+- [ ] **Required Checks** sind grün (ci-honest.yml, Linting, relevante Tests).
 - [ ] **Required Reviews** sind erfüllt (fachlich + technisch, bei hohem Risiko zusätzlicher Lead).
 
 **No-Go, wenn einer der folgenden Punkte zutrifft:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -562,7 +562,7 @@ swift test
 - [ ] **Business Value** ist klar beschrieben und nachvollziehbar.
 - [ ] **Keine neue technische Schuld** (keine neuen TODOs ohne Ticket, keine Code-Smells).
 - [ ] **Risikoabschätzung** ist dokumentiert inkl. Mitigation.
-- [ ] **Required Checks** sind grün (ci-honest.yml, Linting, relevante Tests).
+- [ ] **Required Checks** sind grün (`ci-honest.yml`; Linting/Format lokal geprüft; relevante Tests).
 - [ ] **Required Reviews** sind erfüllt (fachlich + technisch, bei hohem Risiko zusätzlicher Lead).
 
 **No-Go, wenn einer der folgenden Punkte zutrifft:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ RT60_ipad_akusti-scan-APP/
 │   └── Tests/                     # Export-Tests
 │
 └── .github/workflows/             # CI/CD Pipelines
-    ├── ci-honest.yml              # AKTIVE CI: App (xcodebuild) + alle Packages
+    ├── ci-honest.yml              # AKTIVE CI: Packages (Consolidated, Export) + App (xcodebuild)
     └── (build-test.yml, swift.yml,
          self-healing.yml, …)      # stillgelegt (nur workflow_dispatch)
 ```
@@ -338,7 +338,7 @@ Dann auf GitHub:
 - Minderung/Abfang (Fallback, Feature-Flag, Tests, Monitoring) ist beschrieben.
 
 ### Required Checks (müssen grün sein)
-- CI-Workflow **ci-honest.yml** erfolgreich (baut die App via `xcodebuild` und alle Swift-Packages ohne Fehler-Maskierung).
+- CI-Workflow **ci-honest.yml** erfolgreich: baut & testet die Packages `AcoustiScanConsolidated` und `Modules/Export` (`swift test`) und baut die App via `xcodebuild` — ohne Fehler-Maskierung. (Das Manifest `AcoustiScanApp/Package.swift` selbst wird dabei nicht gebaut.)
 - Linting/Formatting (SwiftLint/SwiftFormat) ohne Fehler.
 - Relevante Unit/Integration/UI-Tests vorhanden und grün.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ import XCTest
 
 final class RT60CalculatorTests: XCTestCase {
 
-    func testSabineFormula() {
+    func testRT60CalculationUsingSabineFormula() {
         // Given
         let volume: Double = 100.0  // m3
         let absorptionArea: Double = 20.0  // m²


### PR DESCRIPTION
## Ziel
„Keine bösen Überraschungen für neue Entwickler." CONTRIBUTING.md ist das erste Dokument, das Neulinge lesen — es enthielt mehrere irreführende Stellen.

## Korrekturen (gegen den Code/Repo verifiziert)
| Stelle | Problem | Fix |
|--------|---------|-----|
| Required Checks + Go-Checkliste | Verwiesen auf **stillgelegte** Workflows `build-test.yml`/`swift.yml` als „müssen grün sein"; die **echte** CI `ci-honest.yml` war **nicht genannt** → ein neuer Dev wartet auf Checks, die nie laufen | Auf **`ci-honest.yml`** umgestellt |
| Projektbaum | `MaterialDatabase.swift` (**existiert nicht**) + „500+ Materialien" + „48 Parameter" | Reale Struktur (`DIN18041/`, `Models/`, `AcousticFramework`) |
| Test-Beispiel | `--filter RT60CalculatorTests.testSabineFormula` (Test heißt anders → matcht nichts) | `…testRT60CalculationUsingSabineFormula` |

## Risiko
Keines (reine Doku). Begleitend zur bereits gemergten README-Korrektur (#266), damit beide Einstiegsdokumente konsistent und wahr sind.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_