### PR TITLE
Fix app test that won't compile against the norm-faithful package (classroom/evaluate → A3/evaluateDINCompliance)

### DIFF
--- a/AcoustiScanApp/AcoustiScanAppTests/RT60EvaluatorTests.swift
+++ b/AcoustiScanApp/AcoustiScanAppTests/RT60EvaluatorTests.swift
@@ -4,12 +4,14 @@ import XCTest
 
 final class RT60EvaluatorTests: XCTestCase {
 
+    // A3 (Unterricht/Kommunikation) at V = 120 m³:
+    // T_soll = 0.32·lg(120) − 0.17 ≈ 0.495 s; 1 kHz mid-band tolerance ≈ [0.396, 0.594].
+
     func testEvaluationWithinTolerance() {
-        // RT60Measurement uses (frequency, rt60) constructor
         let measurement = RT60Measurement(frequency: 1000, rt60: 0.49)
-        let deviations = RT60Evaluator.evaluate(
+        let deviations = RT60Evaluator.evaluateDINCompliance(
             measurements: [measurement],
-            roomType: RoomType.classroom,
+            roomType: .a3Education,
             volume: 120.0
         )
 
@@ -18,9 +20,9 @@ final class RT60EvaluatorTests: XCTestCase {
 
     func testEvaluationTooHigh() {
         let measurement = RT60Measurement(frequency: 1000, rt60: 0.75)
-        let deviations = RT60Evaluator.evaluate(
+        let deviations = RT60Evaluator.evaluateDINCompliance(
             measurements: [measurement],
-            roomType: RoomType.classroom,
+            roomType: .a3Education,
             volume: 120.0
         )
 

--- a/README.md
+++ b/README.md
@@ -468,6 +468,12 @@ Proprietary - Alle Rechte vorbehalten
   paralleles SPM-Manifest `AcoustiScanApp/Package.swift`, das **nicht** von der CI
   genutzt wird — bei Build-Einstellungen/Abhängigkeiten ist das **`.xcodeproj`
   maßgeblich**.
+- **App-Tests laufen (noch) nicht in der CI**: Das Test-Target
+  `AcoustiScanAppTests` wird weder vom xcodebuild-Job noch vom Packages-Job
+  ausgeführt. Dadurch bleibt z. B. ein Test, der gegen veraltete Package-APIs
+  kompiliert, unbemerkt — bitte App-Tests vorerst **lokal** ausführen
+  (`swift test` im App-Ordner bzw. ⌘U in Xcode). Diese Tests ins CI-Gate zu
+  nehmen ist ein sinnvoller nächster Schritt.
 
 Die folgenden Feature-Beschreibungen sind als **Zielbild** zu lesen: Auf
 Kompilier-/Testebene verifiziert, die volle Geräte-Laufzeit ist noch nicht


### PR DESCRIPTION
## Bug (gefunden bei der „böse-Überraschungen"-Jagd)
`AcoustiScanApp/AcoustiScanAppTests/RT60EvaluatorTests.swift` kompiliert **nicht** gegen das aktuelle Package:
- ruft `RT60Evaluator.evaluate(...)` auf → existiert nicht (nur `evaluateDINCompliance(...)`)
- nutzt `RoomType.classroom` → existiert nicht mehr (nur **A1–A5**)

Beides wurde bei der DIN-Normtreue-Umstellung (#264) entfernt. Der Fehler blieb **stumm**, weil das Test-Target `AcoustiScanAppTests` von **keiner** CI-Stufe kompiliert wird — genau die Art stiller Falle, die einen neuen Dev trifft, der `swift test` lokal ausführt.

## Fix
- `evaluate` → `evaluateDINCompliance`, `.classroom` → `.a3Education`.
- Assertions bleiben gültig (von Hand verifiziert): A3 @ V=120 m³ → `T_soll≈0,495 s`; 1-kHz-Mittenband `[0,40; 0,59]` → `0,49` = within ✅, `0,75` = tooHigh ✅.
- README-Tech-Debt ergänzt: **App-Tests laufen noch nicht im CI-Gate** → bis dahin lokal ausführen; Aufnahme ins CI ist der empfohlene nächste Schritt.

## Ehrlicher Hinweis zur Verifikation
Die bestehende `ci-honest.yml` kompiliert dieses Test-Target **nicht**, kann den Fix also nicht grün bestätigen. Korrektheit ist hier durch manuelles Nachrechnen belegt (API existiert im Package, Assertions stimmen). Das Schließen genau dieser CI-Lücke ist als Tech-Debt vermerkt.

## Audit-Kontext (kein Fix in diesem PR)
Ein Audit der App-Logik ergab sonst **keine** divergierende Rechen-Logik: Sabine-Konstante (`0.161`) und Absorptions-Summe in `SurfaceStore` stimmen mit dem Package überein. Einziger weiterer Punkt: Der **PDF-Export ist ein Platzhalter** und seine Toleranzprüfung ist symmetrisch (statt des asymmetrischen Bild-2-Bands) — derzeit ohne Aufrufer/ohne erzeugte `dinTargets`, daher latent. Das wäre ein eigener Schritt, sobald der PDF-Export verdrahtet wird.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_