### PR TITLE
Proprietäre LICENSE + Onboarding für externe Mitwirkende (Fork-Weitergabe)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,49 @@
+Proprietary Software License
+============================
+
+Copyright (c) 2025–2026 Marc Schneider-Handrup. All rights reserved.
+
+This software and its source code ("the Software"), including the
+"AcoustiScan" application and the AcoustiScanConsolidated / ReportExport
+packages, are proprietary and confidential.
+
+No license is granted by default
+--------------------------------
+No permission is granted to use, copy, modify, merge, publish, distribute,
+sublicense, or sell copies of the Software, in whole or in part, except as
+expressly authorized in a separate, signed written agreement with the
+copyright holder.
+
+Authorized collaborators
+------------------------
+Access to this repository (for example, as a private fork or as an invited
+collaborator) does NOT by itself grant any rights to the Software. Any such
+access is governed by the terms of the separate written agreement between the
+collaborator and the copyright holder (e.g. a development or contributor
+agreement). Unless that agreement states otherwise:
+
+  - The Software may be used solely for the purpose of contributing to this
+    project on behalf of the copyright holder.
+  - All contributions, modifications, and derivative works created by the
+    collaborator are assigned to / owned by the copyright holder.
+  - The Software and any related information must be kept confidential and
+    must not be redistributed or published.
+
+Third-party components
+----------------------
+The Software may reference Apple frameworks (RoomPlan, ARKit, PDFKit, etc.)
+and any third-party dependencies under their own respective licenses; those
+licenses are unaffected by this notice.
+
+No warranty
+-----------
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING
+FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR ITS USE.
+
+Contact
+-------
+For licensing or usage permission, contact the copyright holder via the
+repository owner account: https://github.com/Darkness308

--- a/ONBOARDING_EXTERNAL.md
+++ b/ONBOARDING_EXTERNAL.md
@@ -1,0 +1,75 @@
+# Onboarding für externe Mitwirkende
+
+Willkommen! Dieses Dokument erklärt, **wie** du an AcoustiScan mitarbeitest und
+**unter welchen Bedingungen**. Bitte zuerst vollständig lesen.
+
+---
+
+## 1. Rechtliches zuerst (wichtig)
+
+- Der Code ist **proprietär** — siehe [LICENSE](LICENSE). **Alle Rechte vorbehalten.**
+- Dass du dieses Repo sehen/forken kannst, gibt dir **noch keine** Rechte am Code.
+  Maßgeblich ist die **gesonderte schriftliche Vereinbarung** mit dem Rechteinhaber
+  (Entwicklungs-/Contributor-Vertrag). Ohne diese Vereinbarung bitte **nicht** mit
+  der Arbeit beginnen und nichts veröffentlichen/weitergeben.
+- **Vertraulichkeit**: Code, Reports, Daten und Zugangsdaten nicht außerhalb des
+  Projekts teilen, nicht in öffentlichen Repos/Gists/Foren posten.
+- **Keine Geheimnisse committen** (API-Keys, Tokens, Apple-Team-IDs, Profile,
+  personenbezogene Daten). Falls versehentlich passiert: sofort melden.
+
+---
+
+## 2. Voraussetzungen (Build/Run)
+
+- **macOS** + **Xcode 15.4** (die CI ist bewusst auf 15.4 gepinnt — bitte lokal
+  dieselbe Major-Version nutzen, sonst weichen Ergebnisse ab).
+- Optional **iPad mit LiDAR** (iPad Pro 2020+) für RoomPlan/ARKit-Laufzeittests.
+- Details & echter Projektstand: **[HANDOFF.md](HANDOFF.md)** ist die ehrliche
+  Quelle der Wahrheit (was verifiziert ist und was nicht).
+
+---
+
+## 3. Mitarbeits-Workflow (Fork → Pull Request)
+
+```bash
+# 1) Repo über die GitHub-Oberfläche forken (Button "Fork").
+# 2) Deinen Fork klonen:
+git clone https://github.com/<dein-user>/RT60_ipad_akusti-scan-APP.git
+cd RT60_ipad_akusti-scan-APP
+
+# 3) Das Original als "upstream" hinzufügen, um aktuell zu bleiben:
+git remote add upstream https://github.com/Darkness308/RT60_ipad_akusti-scan-APP.git
+git fetch upstream
+
+# 4) Branch von aktuellem main:
+git checkout -b feat/meine-aenderung upstream/main
+
+# 5) Vor jeder Arbeit lokal verifizieren (siehe HANDOFF.md §3):
+(cd AcoustiScanConsolidated && swift build && swift test)
+(cd Modules/Export         && swift build && swift test)
+xcodebuild build -project AcoustiScanApp/AcoustiScanApp.xcodeproj \
+  -scheme AcoustiScanApp -destination 'generic/platform=iOS Simulator' \
+  CODE_SIGNING_ALLOWED=NO
+
+# 6) Commit + Push in DEINEN Fork, dann Pull Request gegen Darkness308:main.
+```
+
+- Bitte **kleine, fokussierte PRs** und die Konventionen aus
+  [CONTRIBUTING.md](CONTRIBUTING.md) einhalten.
+- Die einzige verbindliche CI ist **`ci-honest.yml`** — sie muss grün sein.
+  Andere Workflows sind stillgelegt und dürfen **nicht** reaktiviert werden.
+
+---
+
+## 4. Womit anfangen
+
+Die priorisierten nächsten Schritte stehen in **[HANDOFF.md](HANDOFF.md) §5** —
+der wertvollste erste Beitrag ist, die **App-Tests in eine echte CI-Loop** zu
+bringen (Unit-Test-Target in Xcode anlegen + `xcodebuild test` in der CI).
+
+---
+
+## 5. Fragen
+
+Über GitHub-Issues im Repository oder direkt beim Rechteinhaber
+(Account: https://github.com/Darkness308).

--- a/README.md
+++ b/README.md
@@ -407,7 +407,13 @@ Dieser Abschnitt hilft dir, das Projekt zu verstehen und eigene Beiträge zu lei
 
 ## 📜 Lizenz
 
-Proprietary - Alle Rechte vorbehalten
+**Proprietär – Alle Rechte vorbehalten.** Siehe [LICENSE](LICENSE).
+
+Standardmäßig werden **keine** Nutzungs-, Änderungs- oder Weitergaberechte
+gewährt. Zugriff auf das Repository (z. B. als privater Fork oder als
+eingeladene/r Collaborator) begründet **allein noch keine** Rechte am Code —
+maßgeblich ist die gesonderte schriftliche Vereinbarung mit dem
+Rechteinhaber. Externe Mitwirkende: siehe **[ONBOARDING_EXTERNAL.md](ONBOARDING_EXTERNAL.md)**.
 
 ---
 


### PR DESCRIPTION
## Ziel
Das Repo **rechtssicher** an einen externen Entwickler **per Fork** weitergeben. Gewählt: **proprietär bleiben + privat mit Collaborator** (deine Entscheidung).

## Problem
README erklärte „Proprietary – Alle Rechte vorbehalten", aber es gab **keine `LICENSE`-Datei**. Ein Fork von proprietärem Code gewährt dem Externen **von sich aus keinerlei Rechte** → Zusammenarbeit wäre rechtlich ungedeckt.

## Änderungen
- **`LICENSE`** (neu): explizite proprietäre Lizenz. Kernaussagen: standardmäßig keine Rechte; Zugriff/Fork begründet keine Rechte; Collaborator-Bedingungen über **gesonderte schriftliche Vereinbarung**; Beiträge gehen an den Rechteinhaber; Vertraulichkeit; keine Gewährleistung; Drittanbieter-Frameworks unberührt.
- **`README.md`**: Lizenzabschnitt präzisiert + Verweis auf Onboarding.
- **`ONBOARDING_EXTERNAL.md`** (neu): Rechtliches zuerst, dann **Fork→PR-Workflow**, lokale Build-/Verify-Befehle, `ci-honest.yml` als einziges Gate, Einstieg über HANDOFF §5.

## Begleitende organisatorische Schritte (außerhalb des Codes — von dir)
1. **Repo privat lassen**; Externen als **Outside Collaborator** einladen (GitHub → Settings → Collaborators), Rolle i. d. R. *Write*.
2. **Schriftliche Vereinbarung** (Entwicklungs-/Contributor-Vertrag) mit ihm abschließen — die LICENSE verweist genau darauf.
3. Optional: Branch-Protection auf `main` (PR + grüne `ci-honest.yml` erforderlich), damit auch externe PRs durchs Gate müssen.

## Risiko
Keine Code-Logik betroffen (nur LICENSE/Doku). Verifikation durch `ci-honest.yml`.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_