### PR TITLE
Fix M3: erfundene DIN-Sollwerte im Report entfernen, echte T_soll rendern

### DIFF
--- a/Modules/Export/Sources/ReportExport/PDFReportRenderer.swift
+++ b/Modules/Export/Sources/ReportExport/PDFReportRenderer.swift
@@ -65,15 +65,8 @@ public final class PDFReportRenderer {
     private func drawContent(context: UIGraphicsPDFRendererContext, pageRect: CGRect, model: ReportModel) {
         var layout = PDFTextLayout(context: context, pageRect: pageRect)
 
-        // Required frequencies that should always appear (DIN 18041 representative octave bands)
+        // Required frequencies that should always appear as RT60 display rows.
         let requiredFrequencies = [125, 1000, 4000]
-
-        // Use representative DIN 18041 values instead of arbitrary hardcoded ones
-        let representativeDINValues = [
-            (frequency: 125, targetRT60: 0.6, tolerance: 0.1),   // Classroom low frequency
-            (frequency: 1000, targetRT60: 0.5, tolerance: 0.1),  // Office/optimal speech
-            (frequency: 4000, targetRT60: 0.48, tolerance: 0.1)  // High frequency (0.6 * 0.8)
-        ]
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
 
         // Default values that must always appear in the PDF
@@ -156,29 +149,14 @@ public final class PDFReportRenderer {
         layout.drawLine("DIN 18041 Ziel & Toleranz", attributes: sectionAttrs, spacing: 8)
         layout.drawLine("Frequenz [Hz]    T_soll [s]    Toleranz [s]", attributes: textAttrs)
 
-        // Always show representative DIN 18041 standard values
-        for (freq, targetRT60, tolerance) in representativeDINValues {
-            layout.drawLine("\(freq) Hz: T_soll=\(String(format: "%.2f", targetRT60)) s, Toleranz=\(String(format: "%.2f", tolerance)) s", attributes: textAttrs)
+        // Render the actual DIN targets from the model (the room's computed T_soll).
+        if model.din_targets.isEmpty {
+            layout.drawLine("- Hz: T_soll=- s, Toleranz=- s", attributes: textAttrs)
         }
-
-        // Add actual model DIN targets that aren't already covered
         for target in model.din_targets {
             let freq: String
-            if let f = target["freq_hz"], let actualF = f {
-                // Check for valid finite number before converting to Int
-                guard actualF.isFinite && !actualF.isNaN else {
-                    freq = "-"
-                    let tsoll = formattedDecimal(target["t_soll"] ?? nil)
-                    let tol = formattedDecimal(target["tol"] ?? nil)
-                    layout.drawLine("\(freq) Hz: T_soll=\(tsoll) s, Toleranz=\(tol) s", attributes: textAttrs)
-                    continue
-                }
-                let freqInt = Int(actualF.rounded())
-                // Skip if this frequency is already covered by representative values
-                if representativeDINValues.contains(where: { $0.frequency == freqInt }) {
-                    continue
-                }
-                freq = String(freqInt)
+            if let f = target["freq_hz"], let actualF = f, actualF.isFinite && !actualF.isNaN {
+                freq = String(Int(actualF.rounded()))
             } else {
                 freq = "-"
             }
@@ -207,15 +185,8 @@ public final class PDFReportRenderer {
     private func drawMinimalContent(context: UIGraphicsPDFRendererContext, pageRect: CGRect) {
         var layout = PDFTextLayout(context: context, pageRect: pageRect)
 
-        // Required frequencies that should always appear (DIN 18041 representative octave bands)
+        // Required frequencies that should always appear as RT60 display rows.
         let requiredFrequencies = [125, 1000, 4000]
-
-        // Use representative DIN 18041 values instead of arbitrary hardcoded ones
-        let representativeDINValues = [
-            (frequency: 125, targetRT60: 0.6, tolerance: 0.1),   // Classroom low frequency
-            (frequency: 1000, targetRT60: 0.5, tolerance: 0.1),  // Office/optimal speech
-            (frequency: 4000, targetRT60: 0.48, tolerance: 0.1)  // High frequency (0.6 * 0.8)
-        ]
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
 
         let titleAttrs: [NSAttributedString.Key: Any] = [
@@ -251,10 +222,8 @@ public final class PDFReportRenderer {
         layout.addSpacing(12)
         layout.drawLine("DIN 18041 Ziel & Toleranz", attributes: sectionAttrs, spacing: 8)
         layout.drawLine("Frequenz [Hz]    T_soll [s]    Toleranz [s]", attributes: textAttrs)
-        // Show representative DIN 18041 standard values
-        for (freq, targetRT60, tolerance) in representativeDINValues {
-            layout.drawLine("\(freq) Hz: T_soll=\(String(format: "%.2f", targetRT60)) s, Toleranz=\(String(format: "%.2f", tolerance)) s", attributes: textAttrs)
-        }
+        // No model data available -> no DIN targets to show.
+        layout.drawLine("- Hz: T_soll=- s, Toleranz=- s", attributes: textAttrs)
     }
 
     /// Simple text layout helper that automatically handles page breaks.
@@ -313,11 +282,6 @@ public final class PDFReportRenderer {
 
     private func buildContentLines(_ model: ReportModel) -> [String] {
         let requiredFrequencies = [125, 1000, 4000]
-        let representativeDINValues: [(frequency: Int, targetRT60: Double, tolerance: Double)] = [
-            (125, 0.6, 0.1),
-            (1000, 0.5, 0.1),
-            (4000, 0.48, 0.1)
-        ]
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
         let defaultDevice = "ipadpro"
         let defaultVersion = "1.0.0"
@@ -377,19 +341,13 @@ public final class PDFReportRenderer {
         lines.append("")
         lines.append("DIN 18041 Ziel & Toleranz:")
         lines.append("Frequenz [Hz]    T_soll [s]    Toleranz [s]")
-        for (freq, target, tol) in representativeDINValues {
-            lines.append("\(freq) Hz: T_soll=\(String(format: "%.2f", target)) s, Toleranz=\(String(format: "%.2f", tol)) s")
+        if model.din_targets.isEmpty {
+            lines.append("- Hz: T_soll=- s, Toleranz=- s")
         }
         for din in model.din_targets {
             let fStr: String
-            if let fOpt = din["freq_hz"], let f = fOpt {
-                guard f.isFinite && !f.isNaN else {
-                    lines.append("- Hz: T_soll=\(formattedDecimal(din["t_soll"] ?? nil)) s, Toleranz=\(formattedDecimal(din["tol"] ?? nil)) s")
-                    continue
-                }
-                let fi = Int(f.rounded())
-                if representativeDINValues.contains(where: { $0.frequency == fi }) { continue }
-                fStr = String(fi)
+            if let fOpt = din["freq_hz"], let f = fOpt, f.isFinite && !f.isNaN {
+                fStr = String(Int(f.rounded()))
             } else {
                 fStr = "-"
             }
@@ -476,11 +434,6 @@ public final class PDFReportRenderer {
     /// Text-based rendering fallback for platforms without UIKit or AppKit
     public func render(_ model: ReportModel) -> Data {
         let requiredFrequencies = [125, 1000, 4000]
-        let representativeDINValues = [
-            (frequency: 125, targetRT60: 0.6, tolerance: 0.1),
-            (frequency: 1000, targetRT60: 0.5, tolerance: 0.1),
-            (frequency: 4000, targetRT60: 0.48, tolerance: 0.1)
-        ]
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
         let defaultDevice = "ipadpro"
         let defaultVersion = "1.0.0"
@@ -504,19 +457,13 @@ public final class PDFReportRenderer {
         }
 
         var dinContent = ""
-        for (freq, target, tol) in representativeDINValues {
-            dinContent += "\(freq) Hz: T_soll=\(String(format: "%.2f", target)) s, Toleranz=\(String(format: "%.2f", tol)) s\n"
+        if model.din_targets.isEmpty {
+            dinContent += "- Hz: T_soll=- s, Toleranz=- s\n"
         }
         for din in model.din_targets {
             let fStr: String
-            if let fOpt = din["freq_hz"], let f = fOpt {
-                guard f.isFinite && !f.isNaN else {
-                    dinContent += "- Hz: T_soll=\(formattedDecimal(din["t_soll"] ?? nil)) s, Toleranz=\(formattedDecimal(din["tol"] ?? nil)) s\n"
-                    continue
-                }
-                let fi = Int(f.rounded())
-                if representativeDINValues.contains(where: { $0.frequency == fi }) { continue }
-                fStr = String(fi)
+            if let fOpt = din["freq_hz"], let f = fOpt, f.isFinite && !f.isNaN {
+                fStr = String(Int(f.rounded()))
             } else {
                 fStr = "-"
             }

--- a/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
+++ b/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
@@ -152,37 +152,12 @@ public final class ReportHTMLRenderer {
         <div class="small muted">Hinweis: Werte aus Audit-Quelle (T20), Einheiten geprüft.</div>
         """
 
-        // Build DIN targets section with representative values and model data
-        let representativeDINValues = [
-            (frequency: 125, targetRT60: 0.6, tolerance: 0.1),   // Classroom low frequency
-            (frequency: 1000, targetRT60: 0.5, tolerance: 0.1),  // Office/optimal speech
-            (frequency: 4000, targetRT60: 0.48, tolerance: 0.1)  // High frequency (0.6 * 0.8)
-        ]
-
+        // Build the DIN targets section from the model's actual computed targets.
         var dinRows: [String] = []
 
-        // Add representative DIN 18041 standard values first
-        for (freq, targetRT60, tolerance) in representativeDINValues {
-            dinRows.append("<tr><td>\(freq)</td><td>\(String(format: "%.2f", targetRT60))</td><td>\(String(format: "%.2f", tolerance))</td></tr>")
-        }
-
-        // Add model DIN targets that aren't already covered
         for row in m.din_targets {
-            if let freq = row["freq_hz"], let actualFreq = freq {
-                // Check for valid finite number before converting to Int
-                guard actualFreq.isFinite && !actualFreq.isNaN else {
-                    let f = "-"
-                    let ts = numberString(row["t_soll"] ?? nil)
-                    let tol = numberString(row["tol"] ?? nil)
-                    dinRows.append("<tr><td>\(f)</td><td>\(ts)</td><td>\(tol)</td></tr>")
-                    continue
-                }
-                let freqInt = Int(actualFreq.rounded())
-                // Skip if this frequency is already covered by representative values
-                if representativeDINValues.contains(where: { $0.frequency == freqInt }) {
-                    continue
-                }
-                let f = String(freqInt)
+            if let freq = row["freq_hz"], let actualFreq = freq, actualFreq.isFinite && !actualFreq.isNaN {
+                let f = String(Int(actualFreq.rounded()))
                 let ts = numberString(row["t_soll"] ?? nil)
                 let tol = numberString(row["tol"] ?? nil)
                 dinRows.append("<tr><td>\(f)</td><td>\(ts)</td><td>\(tol)</td></tr>")

--- a/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
+++ b/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
@@ -154,6 +154,9 @@ public final class ReportHTMLRenderer {
 
         // Build the DIN targets section from the model's actual computed targets.
         var dinRows: [String] = []
+        if m.din_targets.isEmpty {
+            dinRows.append("<tr><td>-</td><td>-</td><td>-</td></tr>")
+        }
 
         for row in m.din_targets {
             if let freq = row["freq_hz"], let actualFreq = freq, actualFreq.isFinite && !actualFreq.isNaN {

--- a/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
+++ b/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
@@ -172,6 +172,11 @@ public final class ReportHTMLRenderer {
             }
         }
 
+        // Mirror the PDF paths: show an explicit dash row when there are no targets.
+        if dinRows.isEmpty {
+            dinRows.append("<tr><td>-</td><td>-</td><td>-</td></tr>")
+        }
+
         let din = """
         <h2>DIN 18041 Ziel & Toleranz</h2>
         <table>

--- a/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
+++ b/Modules/Export/Sources/ReportExport/ReportHTMLRenderer.swift
@@ -172,11 +172,6 @@ public final class ReportHTMLRenderer {
             }
         }
 
-        // Mirror the PDF paths: show an explicit dash row when there are no targets.
-        if dinRows.isEmpty {
-            dinRows.append("<tr><td>-</td><td>-</td><td>-</td></tr>")
-        }
-
         let din = """
         <h2>DIN 18041 Ziel & Toleranz</h2>
         <table>

--- a/Modules/Export/Tests/PDFRobustnessTests.swift
+++ b/Modules/Export/Tests/PDFRobustnessTests.swift
@@ -204,11 +204,14 @@ final class PDFRobustnessTests: XCTestCase {
         XCTAssertFalse(pdfData3.isEmpty, "PDF should handle all null values")
         let pdfText3 = extractPDFText(pdfData3).lowercased()
 
-        // Should still contain required elements
+        // Should still contain the required RT60 display frequencies
         XCTAssertTrue(pdfText3.contains("125"), "PDF should contain required frequency 125")
         XCTAssertTrue(pdfText3.contains("1000"), "PDF should contain required frequency 1000")
         XCTAssertTrue(pdfText3.contains("4000"), "PDF should contain required frequency 4000")
-        XCTAssertTrue(pdfText3.contains("0.6"), "PDF should contain required DIN value 0.6")
+        // With only null DIN targets, the section must show a dash placeholder,
+        // not a fabricated standard value.
+        XCTAssertTrue(pdfText3.contains("t_soll=-"), "Null DIN targets should render as '-'")
+        XCTAssertFalse(pdfText3.contains("0.6"), "PDF must not contain a fabricated DIN value")
     }
 
     // MARK: - Helpers

--- a/Modules/Export/Tests/PDFRobustnessTests.swift
+++ b/Modules/Export/Tests/PDFRobustnessTests.swift
@@ -28,10 +28,10 @@ final class PDFRobustnessTests: XCTestCase {
             XCTAssertTrue(pdfText.contains(freq), "PDF fehlt erforderliche Frequenz: \(freq) bei leerem Model")
         }
 
-        let requiredDINValues = ["0.6", "0.5", "0.48"]  // Updated to use proper DIN 18041 values
-        for value in requiredDINValues {
-            XCTAssertTrue(pdfText.contains(value), "PDF fehlt erforderlichen DIN-Wert: \(value) bei leerem Model")
-        }
+        // An empty model has no DIN targets, so the section must show the header
+        // and a dash placeholder rather than fabricated standard values.
+        XCTAssertTrue(pdfText.contains("din 18041"), "PDF fehlt DIN-18041-Abschnitt bei leerem Model")
+        XCTAssertTrue(pdfText.contains("t_soll=-"), "PDF sollte '-' statt erfundener DIN-Werte zeigen")
 
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
         for token in coreTokens {
@@ -111,11 +111,10 @@ final class PDFRobustnessTests: XCTestCase {
             XCTAssertTrue(pdfText.contains(freq), "PDF missing required frequency: \(freq)")
         }
 
-        // Check required DIN values - these should ALWAYS be present
-        let requiredDINValues = ["0.6", "0.5", "0.48"]  // Updated to use proper DIN 18041 values
-        for value in requiredDINValues {
-            XCTAssertTrue(pdfText.contains(value), "PDF missing required DIN value: \(value)")
-        }
+        // The DIN section must reflect the model's ACTUAL target (500 Hz, T_soll 0.70),
+        // not fabricated standard values.
+        XCTAssertTrue(pdfText.contains("500 hz: t_soll=0.70"), "PDF should render the model's real DIN target")
+        XCTAssertFalse(pdfText.contains("0.48"), "PDF must not contain the old fabricated DIN value 0.48")
 
         // Check core tokens
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]
@@ -138,36 +137,17 @@ final class PDFRobustnessTests: XCTestCase {
         let pdfData = PDFReportRenderer().render(emptyModel)
         let pdfText = extractPDFText(pdfData).lowercased()
 
-        print("=== DEBUGGING EMPTY MODEL PDF OUTPUT ===")
-        print(pdfText)
-        print("=== END DEBUG OUTPUT ===")
-
-        // Problem statement mentions these specific values should appear:
-        // Frequencies: 125, 1000, 4000 Hz ✓
-        // DIN values: 0.6, 0.5, 0.1 - now properly implemented as 0.6, 0.5, 0.48 from DIN 18041 standard
-        // Core tokens: metadata, device, version, etc. ✓
-
-        // Check if problem statement's DIN values are present (this may fail)
-        let problemStatementDINValues = ["0.6", "0.5", "0.1"]
-        var missingProblemDINs: [String] = []
-        for value in problemStatementDINValues {
-            if !pdfText.contains(value) {
-                missingProblemDINs.append(value)
-            }
+        // An empty model must NOT fabricate DIN target values. Earlier the renderer
+        // hardcoded representative values (0.6 / 0.5 / 0.48) that overwrote the room's
+        // real T_soll; this test now guards against that regression.
+        for fabricated in ["0.48", "t_soll=0.6", "t_soll=0.5"] {
+            XCTAssertFalse(pdfText.contains(fabricated),
+                           "PDF must not contain fabricated DIN value '\(fabricated)' for an empty model")
         }
 
-        if !missingProblemDINs.isEmpty {
-            print("⚠ Problem statement DIN values missing: \(missingProblemDINs)")
-            print("💡 Current implementation now uses proper DIN 18041 values: 0.6, 0.5, 0.48")
-            print("📝 Problem statement examples: 0.6, 0.5, 0.1")
-            // Values now align with DIN 18041 standard
-        }
-
-        // Test what's actually implemented (should pass)
-        let actualDINValues = ["0.6", "0.5", "0.48"]  // Updated to match new implementation
-        for value in actualDINValues {
-            XCTAssertTrue(pdfText.contains(value), "PDF missing implemented DIN value: \(value)")
-        }
+        // Instead, the DIN section shows its header and a dash placeholder.
+        XCTAssertTrue(pdfText.contains("din 18041"), "PDF should still contain the DIN 18041 section header")
+        XCTAssertTrue(pdfText.contains("t_soll=-"), "Empty model should show '-' for DIN targets")
     }
 
     func test_pdf_edge_cases_that_might_cause_failures() {

--- a/Modules/Export/Tests/ReportContractTests.swift
+++ b/Modules/Export/Tests/ReportContractTests.swift
@@ -136,12 +136,14 @@ final class ReportContractTests: XCTestCase {
             .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
             .lowercased()
 
-        // Assert - DIN-Zielwerte sollten in beiden Ausgaben vorkommen
-        let targetValues = ["0.6", "0.5", "0.48"]  // Updated to use proper DIN 18041 values
+        // Assert - the model's ACTUAL DIN target values must appear in both outputs
+        // (no fabricated standard values).
+        let targetValues = ["0.65", "0.55"]
         for value in targetValues {
             XCTAssertTrue(pdfText.contains(value), "PDF fehlt DIN-Zielwert: \(value)")
             XCTAssertTrue(htmlText.contains(value), "HTML fehlt DIN-Zielwert: \(value)")
         }
+        XCTAssertFalse(pdfText.contains("0.48"), "PDF darf keinen erfundenen DIN-Wert (0.48) enthalten")
     }
 
     func test_pdf_includes_required_frequencies_and_din_values() {
@@ -169,11 +171,10 @@ final class ReportContractTests: XCTestCase {
             XCTAssertTrue(pdfText.contains(freq), "PDF fehlt erforderliche Frequenz: \(freq)")
         }
 
-        // Assert - Required DIN values should always appear in PDF
-        let requiredDINValues = ["0.6", "0.5", "0.48"]  // Updated to use proper DIN 18041 values
-        for value in requiredDINValues {
-            XCTAssertTrue(pdfText.contains(value), "PDF fehlt erforderlichen DIN-Wert: \(value)")
-        }
+        // Assert - the model's ACTUAL DIN target (250 Hz, T_soll 0.60) must appear,
+        // and no fabricated standard values.
+        XCTAssertTrue(pdfText.contains("250 hz: t_soll=0.60"), "PDF fehlt der echte DIN-Zielwert des Modells")
+        XCTAssertFalse(pdfText.contains("0.48"), "PDF darf keinen erfundenen DIN-Wert (0.48) enthalten")
 
         // Assert - Core tokens should always appear in PDF
         let coreTokens = ["rt60 bericht", "metadaten", "geraet", "ipadpro", "version", "1.0.0"]


### PR DESCRIPTION
## Bug M3 (High, **live** — gefunden im systematischen Code-Review)
`PDFReportRenderer` (UIKit-, AppKit-, Text-Pfad) und `ReportHTMLRenderer` hatten einen hartcodierten Block:
```swift
representativeDINValues = [ (125, 0.6, 0.1) /*Classroom*/, (1000, 0.5, 0.1) /*Office*/, (4000, 0.48, 0.1) ]
```
Diese **erfundenen** Werte wurden **immer** gedruckt — und die **echten** `model.din_targets` bei 125/1000/4000 Hz wurden per `contains(where:)` **übersprungen**. Ein realer Raum zeigte also im „DIN 18041 Ziel & Toleranz"-Abschnitt **fabrizierte** Sollwerte an genau den Rand-/Mittenbändern statt seines berechneten `T_soll`. Die Labels „Classroom"/„Office" verweisen zudem auf Raumtypen, die mit der Normtreue-Umstellung (A1–A5) entfernt wurden.

Reichweite: **kein Platzhalter** — `PDFReportRenderer`/`ReportHTMLRenderer` werden von den Export-Tests real ausgeführt und sind der Render-Pfad des Report-Tools.

## Fix
- Hartcodierten Block aus **allen vier** PDF-Render-Pfaden + dem HTML-Renderer entfernt.
- Es werden **nur noch** die echten `model.din_targets` gerendert; bei leerem Modell ein `-`-Platzhalter.
- Die Export-Tests, die die Fakes **zementiert** hatten (`PDFRobustnessTests`, `ReportContractTests`, u. a. `requiredDINValues = ["0.6","0.5","0.48"]`), auf die **echten** Modellwerte umgestellt + Regressions-Guard gegen das Wiederauftauchen von `0.48`.

Diff: −142/+45 Zeilen.

## Verifikation — ehrlich
Diese Umgebung hat **kein Swift-Toolchain**; ich konnte den Fix **nicht lokal kompilieren/testen**. **`ci-honest.yml` (Modules/Export `swift test`) ist der Richter.** Sollte ein Token-Assert wider Erwarten brechen, justiere ich nach.

## Kontext
Erster von drei Fixes aus dem Review (M3 → dann H2 Volumen-Range, dann H1 8000 Hz), je eigener PR, einzeln CI-verifiziert. Die DIN-Recherche bestätigte separat die Kern-Koeffizienten A1–A5; eine offene Frage (Toleranz-Asymmetrie bei 4000 Hz) wird getrennt dokumentiert, nicht geraten.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_