### PR TITLE
Fix H2: Volumen außerhalb des DIN-Gültigkeitsbereichs kennzeichnen (statt still extrapolieren)

### DIFF
--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
@@ -68,10 +68,26 @@ extension ReportModel {
             ]
         }
 
-        let validity = [
+        // DIN 18041 validity: surface whether the room volume lies within the
+        // usage group's valid range. The target equation T_soll = a·lg(V)+b is only
+        // defined inside this range; outside it the value is an extrapolation and
+        // must be flagged rather than presented as a normative target.
+        let range = reportData.roomType.validVolumeRange
+        let withinRange = reportData.roomType.isVolumeWithinValidRange(reportData.volume)
+        let rangeText = "\(Int(range.lowerBound))–\(Int(range.upperBound)) m³"
+
+        var validity = [
             "method": "ISO3382-1",
-            "bands": "octave"
+            "bands": "octave",
+            "din_volume_range": rangeText,
+            "din_volume_valid": withinRange
+                ? "ja"
+                : "NEIN – Volumen \(Int(reportData.volume)) m³ außerhalb gültigem Bereich (\(rangeText)); T_soll extrapoliert"
         ]
+        if !withinRange {
+            validity["din_hinweis"] =
+                "Sollwerte sind außerhalb des für Gruppe \(reportData.roomType.groupLabel) gültigen Volumenbereichs nicht norm­konform."
+        }
 
         let audit = [
             "hash": "DEMO\(abs(reportData.date.hashValue))",

--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
@@ -409,4 +409,34 @@ final class ReportContractTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - H2: volume validity flag
+
+    private func makeReportData(roomType: RoomType, volume: Double) -> ReportData {
+        ReportData(
+            date: "2025-07-21",
+            roomType: roomType,
+            volume: volume,
+            rt60Measurements: [RT60Measurement(frequency: 1000, rt60: 0.5)],
+            dinResults: [RT60Deviation(frequency: 1000, measuredRT60: 0.5, targetRT60: 0.5, status: .withinTolerance)],
+            acousticFrameworkResults: [:],
+            surfaces: [],
+            recommendations: []
+        )
+    }
+
+    func testReportFlagsVolumeWithinValidRange() {
+        // A3 valid 30–5000 m³; 150 m³ is inside.
+        let model = ReportModel.from(makeReportData(roomType: .a3Education, volume: 150))
+        XCTAssertEqual(model.validity["din_volume_valid"], "ja")
+        XCTAssertNil(model.validity["din_hinweis"])
+    }
+
+    func testReportFlagsVolumeOutsideValidRange() {
+        // A4 valid 30–500 m³; 2000 m³ is outside → must be flagged, not silently extrapolated.
+        let model = ReportModel.from(makeReportData(roomType: .a4EducationInclusive, volume: 2000))
+        XCTAssertNotEqual(model.validity["din_volume_valid"], "ja")
+        XCTAssertTrue(model.validity["din_volume_valid"]?.contains("außerhalb") ?? false)
+        XCTAssertNotNil(model.validity["din_hinweis"])
+    }
 }


### PR DESCRIPTION
## Bug H2 (High, **live** — aus dem systematischen Code-Review)
`RoomType.validVolumeRange` / `isVolumeWithinValidRange` existierten, wurden aber **nirgends aufgerufen** (nur in Tests referenziert). Ein Volumen außerhalb des Gültigkeitsbereichs einer Gruppe (z. B. **A4 über 500 m³**, A1 über 1000 m³) lieferte daher einen **extrapolierten** `T_soll`, der als normativer Sollwert im Gutachten erschien — ohne jeden Vorbehalt. Die Sollwertgleichung `T_soll = a·lg(V)+b` ist nach DIN 18041:2016-03 (Tabelle 5) **nur innerhalb** des jeweiligen Bereichs definiert.

## Fix (Entscheidung: „out-of-range kennzeichnen")
`ReportModel.from` prüft das Volumen jetzt gegen `validVolumeRange` und macht das Ergebnis in der **validity-Sektion** des Reports sichtbar (wird in PDF **und** HTML gerendert):
- `din_volume_range` — der gültige Bereich der Gruppe (z. B. „30–500 m³")
- `din_volume_valid` — „ja" oder „NEIN – Volumen … außerhalb gültigem Bereich …; T_soll extrapoliert"
- `din_hinweis` — Zusatzhinweis nur bei out-of-range

So bleibt der Wert sichtbar (wie gewünscht), aber **klar als nicht-normkonform markiert** statt still als Sollwert ausgegeben. Keine bestehende API geändert.

Tests: in-range (A3 @ 150 m³ → „ja") und out-of-range (A4 @ 2000 m³ → Flag + Hinweis).

## Verifikation — ehrlich
Kein Swift-Toolchain hier; **`ci-honest.yml` (AcoustiScanConsolidated `swift test`) ist der Richter.**

## Kontext
Zweiter von drei Review-Fixes (M3 ✅ gemergt #273 → **H2** → H1 8000 Hz). Je eigener PR, einzeln CI-verifiziert.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_