### PR TITLE
Fix H1: 8000-Hz-Band als „nicht bewertet n. DIN 18041" kennzeichnen (statt still droppen)

### DIFF
--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportModel.swift
@@ -89,6 +89,23 @@ extension ReportModel {
                 "Sollwerte sind außerhalb des für Gruppe \(reportData.roomType.groupLabel) gültigen Volumenbereichs nicht norm­konform."
         }
 
+        // DIN 18041 only verifies specific octave bands per usage group
+        // (125–4000 Hz for A1–A4, 250–2000 Hz for A5). Measured bands outside that
+        // set (e.g. 8000 Hz) appear in the RT60 table but are NOT part of the
+        // compliance evaluation — make that explicit instead of dropping them silently.
+        let evaluated = Set(reportData.roomType.evaluationFrequencies)
+        let unevaluated = reportData.rt60Measurements
+            .map { $0.frequency }
+            .filter { !evaluated.contains($0) }
+            .sorted()
+        validity["din_bewertete_baender"] = reportData.roomType.evaluationFrequencies
+            .map { "\($0)" }.joined(separator: ", ") + " Hz"
+        if !unevaluated.isEmpty {
+            validity["din_nicht_bewertet"] =
+                unevaluated.map { "\($0)" }.joined(separator: ", ")
+                + " Hz – gemessen, aber nicht bewertet n. DIN 18041 (Gruppe \(reportData.roomType.groupLabel))"
+        }
+
         let audit = [
             "hash": "DEMO\(abs(reportData.date.hashValue))",
             "source": "consolidated"

--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
@@ -439,4 +439,49 @@ final class ReportContractTests: XCTestCase {
         XCTAssertTrue(model.validity["din_volume_valid"]?.contains("außerhalb") ?? false)
         XCTAssertNotNil(model.validity["din_hinweis"])
     }
+
+    // MARK: - H1: bands measured but not evaluated by DIN
+
+    private func makeReportData(
+        roomType: RoomType,
+        volume: Double,
+        measuredFrequencies: [Int]
+    ) -> ReportData {
+        ReportData(
+            date: "2025-07-21",
+            roomType: roomType,
+            volume: volume,
+            rt60Measurements: measuredFrequencies.map { RT60Measurement(frequency: $0, rt60: 0.5) },
+            dinResults: [],
+            acousticFrameworkResults: [:],
+            surfaces: [],
+            recommendations: []
+        )
+    }
+
+    func testReportMarks8000HzAsNotEvaluated() {
+        // A3 evaluates 125–4000 Hz; an 8000 Hz measurement must be reported as
+        // measured-but-not-evaluated rather than silently dropped.
+        let data = makeReportData(
+            roomType: .a3Education,
+            volume: 150,
+            measuredFrequencies: [125, 250, 500, 1000, 2000, 4000, 8000]
+        )
+        let model = ReportModel.from(data)
+        let note = model.validity["din_nicht_bewertet"]
+        XCTAssertNotNil(note)
+        XCTAssertTrue(note?.contains("8000") ?? false)
+        XCTAssertFalse(model.validity["din_bewertete_baender"]?.contains("8000") ?? true)
+    }
+
+    func testReportHasNoUnevaluatedNoteWhenAllBandsCovered() {
+        // Only evaluated bands present → no "nicht bewertet" note.
+        let data = makeReportData(
+            roomType: .a3Education,
+            volume: 150,
+            measuredFrequencies: [125, 250, 500, 1000, 2000, 4000]
+        )
+        let model = ReportModel.from(data)
+        XCTAssertNil(model.validity["din_nicht_bewertet"])
+    }
 }


### PR DESCRIPTION
## Bug H1 (High, **live** — aus dem systematischen Code-Review)
`calculateFrequencySpectrum` erzeugt 7 Bänder inkl. **8000 Hz**, aber die DIN-Bewertung deckt nur **125–4000 Hz** (A1–A4) bzw. **250–2000 Hz** (A5) ab. `RT60Evaluator` verwirft per `compactMap`/`first(where:)` jede gemessene Frequenz ohne passendes Target **lautlos**. Folge: Die RT60-Tabelle zeigt einen 8000-Hz-Wert **ohne Status**, und die „DIN-Konformität %" ignoriert ihn **stillschweigend**.

## Fix (Entscheidung: „als ‚nicht bewertet' labeln")
`ReportModel.from` hält in der **validity-Sektion** (PDF + HTML) jetzt fest:
- `din_bewertete_baender` — welche Oktavbänder die Gruppe tatsächlich bewertet (z. B. „125, 250, 500, 1000, 2000, 4000 Hz")
- `din_nicht_bewertet` — gemessene, aber **nicht** bewertete Bänder, z. B. **„8000 Hz – gemessen, aber nicht bewertet n. DIN 18041 (Gruppe A3)"**

Nichts verschwindet mehr unsichtbar; der 8000-Hz-Wert bleibt in der RT60-Tabelle, ist aber klar als außerhalb der DIN-Bewertung gekennzeichnet. Additiv, keine bestehende API/Render-Logik geändert. (Greift konsistent auch für A5, wo 125/4000/8000 Hz außerhalb der bewerteten 250–2000 Hz liegen.)

Tests: 8000-Hz-Fall (Note vorhanden, enthält „8000", nicht in den bewerteten Bändern) und der All-Covered-Fall (keine Note).

## Verifikation — ehrlich
Kein Swift-Toolchain hier; **`ci-honest.yml` (AcoustiScanConsolidated `swift test`) ist der Richter.**

## Kontext
Dritter und letzter Review-Fix (M3 ✅ #273 · H2 ✅ #274 · **H1**). Damit sind die drei reichweitenstarken Funde aus dem systematischen Code-Review adressiert.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_