### PR TITLE
Green-gewaschene No-op/Tautologie-Tests durch echte Assertions ersetzen

### DIFF
--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/AcoustiScanConsolidatedTests.swift
@@ -306,12 +306,22 @@ final class PDFExportTests: XCTestCase {
         XCTAssertEqual(reportData.recommendations.count, 1)
     }
 
-    func testPDFGenerationAvailabilityDoesNotCrash() {
-        #if canImport(UIKit)
-        XCTAssertTrue(true)
-        #else
-        XCTAssertTrue(true)
-        #endif
+    func testPDFGenerationProducesNonEmptyData() {
+        // Previously both #if branches asserted XCTAssertTrue(true) (a no-op).
+        // Render an actual report and assert it produces non-empty output.
+        let reportData = ConsolidatedPDFExporter.ReportData(
+            date: "2025-01-01",
+            roomType: .a3Education,
+            volume: 150.0,
+            rt60Measurements: [RT60Measurement(frequency: 1000, rt60: 0.6)],
+            dinResults: [RT60Deviation(frequency: 1000, measuredRT60: 0.6, targetRT60: 0.55, status: .withinTolerance)],
+            acousticFrameworkResults: [:],
+            surfaces: [],
+            recommendations: ["Test"]
+        )
+        let model = ReportModel.from(reportData)
+        let data = ReportHTMLRenderer().render(model)
+        XCTAssertFalse(data.isEmpty, "HTML report rendering should produce non-empty data")
     }
 }
 

--- a/Modules/Export/Tests/PDFReportSnapshotTests.swift
+++ b/Modules/Export/Tests/PDFReportSnapshotTests.swift
@@ -35,10 +35,22 @@ final class PDFReportSnapshotTests: XCTestCase {
 
         XCTAssertEqual(doc.pageCount, 1)
 
+        // A literal byte-hash snapshot would be flaky (PDFs embed creation
+        // dates/IDs, so the bytes differ between runs). Instead assert real,
+        // content-based invariants that fail if rendering breaks, plus that the
+        // hash is well-formed (64 hex chars) so the hashing path is exercised.
         let h = Self.hash(data)
-        // Erwartungswert beim ersten Lauf ermitteln & festschreiben:
-        // XCTFail("Hash=\(h)")  // einmalig ausgeben, dann Wert unten eintragen
-        XCTAssertEqual(h, h) // Platzhalter: trage den erwarteten Hash ein
+        XCTAssertEqual(h.count, 64, "SHA256 hex digest must be 64 chars")
+        XCTAssertTrue(h.allSatisfy { $0.isHexDigit }, "hash must be hex")
+
+        let text = (0..<doc.pageCount)
+            .compactMap { doc.page(at: $0)?.string }
+            .joined(separator: "\n")
+            .lowercased()
+        XCTAssertTrue(text.contains("rt60 bericht"), "PDF should contain the report title")
+        XCTAssertTrue(text.contains("din 18041"), "PDF should contain the DIN section")
+        XCTAssertTrue(text.contains("0.60"), "PDF should render the model's T_soll value")
+        XCTAssertTrue(text.contains("wandabsorber ergänzen"), "PDF should render recommendations")
         #else
         // On platforms without PDFKit, just verify the PDF renderer produces data
         let model = ReportModel(

--- a/Tools/LogParser/RT60LogParserTests.swift
+++ b/Tools/LogParser/RT60LogParserTests.swift
@@ -47,8 +47,9 @@ final class RT60LogParserTests: XCTestCase {
         XCTAssertFalse(model.summary.checksum_ok) // Fixture-Checksum bewusst "falsch"
     }
 
-    func test_cli_exits_nonzero_on_format_error() throws {
-        // Hier könnte ein fehlerhaftes Fixture genutzt werden (nicht vorhanden) - Placeholder:
+    func test_malformed_band_line_does_not_yield_valid_band() throws {
+        // Previously a placeholder (XCTAssertTrue(true)). A malformed T20 line
+        // ("125Hz abc" — no numeric value) must not parse into a valid 125 Hz band.
         let bad = """
         Setup:
         AppVersion=1.0.0
@@ -56,7 +57,12 @@ final class RT60LogParserTests: XCTestCase {
         T20:
         125Hz abc
         """
-        _ = bad // Integriere später in CLI E2E-Tests
-        XCTAssertTrue(true)
+        let model = try RT60LogParser().parse(text: bad, sourceFile: "bad")
+        if let b125 = model.bands.first(where: { $0.freq_hz == 125 }) {
+            XCTAssertFalse(b125.valid, "Malformed '125Hz abc' must not be a valid band")
+            XCTAssertNil(b125.t20_s, "Malformed line must not yield a numeric T20")
+        }
+        // (If the parser drops the malformed line entirely, that is also acceptable;
+        // the contract is simply that it must never become a valid numeric band.)
     }
 }


### PR DESCRIPTION
## Befund (aus dem CI-/Test-Audit, EKS-Engpassanalyse)
Drei Tests, die **nie fehlschlagen können** — genau das Green-Washing-Muster, vor dem CLAUDE.md warnt:

1. **`PDFReportSnapshotTests` — `XCTAssertEqual(h, h)`** (Hash mit sich selbst verglichen; der echte Erwartungswert wurde nie eingetragen). Ein literaler Byte-Hash wäre **flaky** (PDFs betten Datum/IDs ein), daher stattdessen **inhaltliche Invarianten**: Titel, DIN-Abschnitt, gerendertes `T_soll` 0.60, Empfehlung — plus „Hash ist 64-stelliger Hex" (übt den Hashing-Pfad). Kann real brechen, wenn das Rendering kaputtgeht.
2. **`testPDFGenerationAvailabilityDoesNotCrash`** — beide `#if`/`#else`-Zweige waren `XCTAssertTrue(true)`. Ersetzt durch echtes Rendern → Nicht-leer-Assertion.
3. **`Tools/LogParser` `test_cli_exits_nonzero_on_format_error`** — war `_ = bad; XCTAssertTrue(true)`. Parst jetzt die malformte Zeile und prüft, dass sie **nie** ein gültiges numerisches Band wird.

## Verifikation — ehrlich
`ci-honest.yml` (Packages-Job) führt die ersten beiden aus. Der LogParser-Test läuft in **keiner** CI (eigene dokumentierte Lücke — `Tools/LogParser` hat kein Package/CI); trotzdem korrigiert, damit er nicht als grüner Schein dasteht.

## Kontext
Erster, schnell schließbarer Fund aus der EKS-Engpassanalyse der Verifizierungslücken. Der **eigentliche Engpass** (App-Tests laufen in keiner CI) und ein gravierenderer Befund (die App *misst* RT60 nicht, sie *prognostiziert* es) folgen separat zur Entscheidung.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn