### PR TITLE
Governance: echtes CODEOWNERS + Durchsetzungs-Settings dokumentieren (vor Fork)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS — wer Änderungen freigeben muss.
 #
 # Wirkt nur, wenn auf `main` Branch-Protection mit "Require review from Code Owners"
-# aktiv ist (GitHub → Settings → Branches). Siehe HANDOFF §10 / Governance.
+# aktiv ist (GitHub → Settings → Branches). Siehe HANDOFF §11 / Governance.
 #
 # Die zuvor hier eingetragenen Teams (@your-org/...) existierten NICHT und haben
 # daher nichts erzwungen. Bis echte Teams angelegt sind, ist der Repo-Owner

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,24 @@
-# Kernmodule
-/Tools/LogParser/           @your-org/dsp-team
-/Modules/Export/            @your-org/ios-team
-/Schemas/                   @your-org/qa-team
-/Docs/                      @your-org/docs-team
+# CODEOWNERS — wer Änderungen freigeben muss.
+#
+# Wirkt nur, wenn auf `main` Branch-Protection mit "Require review from Code Owners"
+# aktiv ist (GitHub → Settings → Branches). Siehe HANDOFF §10 / Governance.
+#
+# Die zuvor hier eingetragenen Teams (@your-org/...) existierten NICHT und haben
+# daher nichts erzwungen. Bis echte Teams angelegt sind, ist der Repo-Owner
+# Fallback-Reviewer für alles.
+
+# Default: alles braucht Owner-Freigabe
+*                           @Darkness308
+
+# Akustik-Kern (normtreue DIN/RT60-Logik — mit besonderer Sorgfalt prüfen)
+/AcoustiScanConsolidated/   @Darkness308
+
+# Report-/Export-Rendering
+/Modules/Export/            @Darkness308
+
+# iOS-App
+/AcoustiScanApp/            @Darkness308
+
+# Verträge & CI (Schemas, Workflows) — Änderungen hier sind besonders sensibel
+/Schemas/                   @Darkness308
+/.github/                   @Darkness308

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -211,7 +211,7 @@ im GitHub-UI setzen (nicht im Code, nicht von einer Sandbox):
    - ☑ Require branches up to date before merging
    Ohne dies kann (auch der externe Dev) **rot mergen** oder direkt auf `main` pushen.
 2. **Actions-Berechtigungen für Forks** (Settings → Actions → General): Workflow-Permissions auf
-   *read-only* + „Require approval for all outside collaborators" (Security-Review-Gate, vgl. LICENSE/Onboarding).
+   *read-only* + „Require approval for all outside collaborators" (Security-Review-Gate, vgl. LICENSE und ONBOARDING_EXTERNAL.md).
 3. **CODEOWNERS** ist jetzt real (`@Darkness308` statt nicht-existenter `@your-org/*`-Teams);
    greift aber erst mit „Require review from Code Owners" aus Punkt 1. Sobald echte Teams
    existieren, dort eintragen.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -198,6 +198,27 @@ einfließen.
 ersetzt. Verbleibende **immer-skippende** Tests (`TimeoutConfigurationTests` via Datei-Existenz)
 sollten gelöscht oder mit echten Fixtures versehen werden.
 
+## 11. Governance / Systemdurchsetzung (vor dem Fork einzurichten)
+
+Die ehrliche CI **läuft** automatisch (push/PR), aber „laufen" ≠ „erzwungen". Drei Dinge
+entscheiden, ob roter/ungeprüfter Code blockiert wird — zwei davon kann **nur der Repo-Owner**
+im GitHub-UI setzen (nicht im Code, nicht von einer Sandbox):
+
+1. **Branch-Protection auf `main`** (Settings → Branches → Add rule):
+   - ☑ Require a pull request before merging
+   - ☑ Require status checks to pass → **`Swift packages (build + test)`** und **`iOS app (xcodebuild)`** als *required* markieren
+   - ☑ Require review from Code Owners
+   - ☑ Require branches up to date before merging
+   Ohne dies kann (auch der externe Dev) **rot mergen** oder direkt auf `main` pushen.
+2. **Actions-Berechtigungen für Forks** (Settings → Actions → General): Workflow-Permissions auf
+   *read-only* + „Require approval for all outside collaborators" (Security-Review-Gate, vgl. LICENSE/Onboarding).
+3. **CODEOWNERS** ist jetzt real (`@Darkness308` statt nicht-existenter `@your-org/*`-Teams);
+   greift aber erst mit „Require review from Code Owners" aus Punkt 1. Sobald echte Teams
+   existieren, dort eintragen.
+
+> Status dieser drei Punkte ist **von der Sandbox aus nicht prüfbar** (kein Branch-Protection-API-Zugriff).
+> Bitte im UI verifizieren — das ist die eigentliche Durchsetzung hinter der „ehrlichen CI".
+
 ---
 
 *Letzte Aktualisierung dieses Dokuments: 2026-05-30. Bei Abweichungen zwischen diesem Dokument und dem Code


### PR DESCRIPTION
## Befund (Governance / Systemdurchsetzung — deine Frage „gov vorhanden?")
Verifiziert, nicht behauptet:
- ✅ `ci-honest.yml` triggert **automatisch** (push/PR); Masking-Workflows sind stillgelegt.
- ❌ **CODEOWNERS war ein Platzhalter** — `@your-org/dsp-team`, `@your-org/ios-team` etc. existieren nicht → erzwang **nichts**.
- ❓ Ob die CI ein **Required Check** auf `main` ist, kann **nur der Owner** im UI sehen — kein Branch-Protection-API-Tool hier.

## Änderung
1. **`.github/CODEOWNERS` real gemacht:** echte Owner-Handle `@Darkness308` als Fallback-Reviewer für alle Pfade, inkl. **Akustik-Kern** (`AcoustiScanConsolidated`), `Modules/Export`, App, `Schemas/` und `.github/` (sensible Verträge/CI). Greift, sobald „Require review from Code Owners" aktiv ist.
2. **HANDOFF §11 „Governance / Systemdurchsetzung":** die **drei** Durchsetzungs-Schalter, die nur der Owner im GitHub-UI setzen kann:
   - Branch-Protection auf `main` + die **zwei `ci-honest`-Jobs als required status checks**
   - Require Code-Owner-Review
   - Fork-Actions auf read-only + Approval für Outside-Collaborators (deckt sich mit dem Security-Review-Gate)

   Mit klarem Hinweis: Status **von der Sandbox aus nicht prüfbar** → im UI verifizieren. Das schließt die Lücke zwischen „CI läuft" und „CI ist erzwungen" vor dem Fork.

## Risiko
Keines im Code (CODEOWNERS + Doku). Die eigentliche Aktivierung ist eine Owner-Einstellung, kein Merge.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_