### PR TITLE
Fix Daten-Überschreibung: gescanntes Volumen + persistenter Store vor Clobbering schützen

### DIFF
--- a/AcoustiScanApp/AcoustiScanApp/App/ContentView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/App/ContentView.swift
@@ -72,10 +72,13 @@ struct ContentView: View {
             .accessibilityIdentifier("tabExport")
         }
         .accessibilityIdentifier("contentView")
-        .onAppear(perform: syncRoomVolume)
-        .onChange(of: roomLength) { _, _ in syncRoomVolume() }
-        .onChange(of: roomWidth) { _, _ in syncRoomVolume() }
-        .onChange(of: roomHeight) { _, _ in syncRoomVolume() }
+        // Seed an initial volume only if none exists yet (so RT60 works without a
+        // scan), but never on later re-appears — that would clobber a scanned
+        // volume with the manual defaults.
+        .onAppear { syncRoomVolume(userEdited: false) }
+        .onChange(of: roomLength) { _, _ in syncRoomVolume(userEdited: true) }
+        .onChange(of: roomWidth) { _, _ in syncRoomVolume(userEdited: true) }
+        .onChange(of: roomHeight) { _, _ in syncRoomVolume(userEdited: true) }
     }
 
     /// Scanner tab: real RoomPlan capture where available, otherwise a fallback
@@ -94,7 +97,14 @@ struct ContentView: View {
 
     /// Keep the shared room volume in sync with the manual dimension entry so
     /// the RT60 calculation has a volume even without a LiDAR scan.
-    private func syncRoomVolume() {
+    ///
+    /// - Parameter userEdited: true when triggered by an actual edit of a
+    ///   dimension field. Manual entry must not silently overwrite a volume that
+    ///   came from a LiDAR/RoomPlan scan, so we only write when the user edited a
+    ///   field, or when there is no scanned volume yet (store.roomVolume == 0).
+    private func syncRoomVolume(userEdited: Bool) {
+        let hasScannedVolume = store.roomVolume > 0 && store.roomDimensions != nil
+        guard userEdited || !hasScannedVolume else { return }
         store.roomVolume = roomLength * roomWidth * roomHeight
         store.roomDimensions = (width: roomWidth, height: roomHeight, depth: roomLength)
     }

--- a/AcoustiScanApp/AcoustiScanApp/Models/SurfaceStore.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Models/SurfaceStore.swift
@@ -41,6 +41,14 @@ public class SurfaceStore: ObservableObject {
     /// Room dimensions (optional)
     @Published public var roomDimensions: (width: Double, height: Double, depth: Double)?
 
+    /// Persistence key for the serialized store.
+    private static let storeKey = "surfaceStore"
+
+    /// Guards against clobbering good data: stays false if a saved blob exists
+    /// but could not be decoded, so `saveSurfaces()` refuses to overwrite it
+    /// with the in-memory default. Set true on a clean load or empty start.
+    private var canPersist = false
+
     /// Initialize empty store
     public init() {
         loadSurfaces()
@@ -144,9 +152,22 @@ public class SurfaceStore: ObservableObject {
             roomDimensions: roomDimensions
         )
 
+        // Refuse to overwrite a saved blob we could not decode: persisting the
+        // in-memory default here would permanently destroy still-valid data.
+        guard canPersist else {
+            ErrorLogger.log(
+                NSError(domain: "SurfaceStore", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Skipped save: previous data could not be loaded; not overwriting it."
+                ]),
+                context: "SurfaceStore.saveSurfaces",
+                level: .error
+            )
+            return
+        }
+
         do {
             let encoded = try JSONEncoder().encode(data)
-            UserDefaults.standard.set(encoded, forKey: "surfaceStore")
+            UserDefaults.standard.set(encoded, forKey: Self.storeKey)
         } catch {
             ErrorLogger.log(
                 error,
@@ -157,7 +178,9 @@ public class SurfaceStore: ObservableObject {
     }
 
     private func loadSurfaces() {
-        guard let data = UserDefaults.standard.data(forKey: "surfaceStore") else {
+        guard let data = UserDefaults.standard.data(forKey: Self.storeKey) else {
+            // No saved data yet → a fresh, empty store is safe to persist.
+            canPersist = true
             return
         }
 
@@ -167,10 +190,15 @@ public class SurfaceStore: ObservableObject {
             roomVolume = decoded.roomVolume
             roomName = decoded.roomName
             roomDimensions = decoded.roomDimensions
+            canPersist = true
         } catch {
+            // Decode failed (e.g. Codable schema drift). Keep canPersist = false so we
+            // never overwrite the unreadable-but-present blob, and back it up so a
+            // future migration can recover it instead of losing it silently.
+            UserDefaults.standard.set(data, forKey: Self.storeKey + ".corrupt")
             ErrorLogger.log(
                 error,
-                context: "SurfaceStore.loadSurfaces",
+                context: "SurfaceStore.loadSurfaces (backed up to \(Self.storeKey).corrupt; saves disabled to protect data)",
                 level: .error
             )
         }


### PR DESCRIPTION
## Befund (Daten-Integritäts-Audit — deine Anforderung „Daten dürfen keine anderen Daten überschreiben")
Zwei **echte HIGH-Bugs**, am Code verifiziert:

**#2 — Gescanntes Raumvolumen wird durch manuelle Defaults überschrieben.**
`ContentView.syncRoomVolume()` lief **bedingungslos auf `.onAppear`**. Szenario: Nutzer scannt Raum (Store hält gemessenes Volumen, z. B. 78 m³) → View erscheint erneut → `onAppear` schreibt `5×4×2.7 = 54 m³` + manuelle Maße ins geteilte Store. Stille Korruption gemessener Daten durch unbezogene Defaults.
→ **Fix:** Sync nur noch bei **echtem manuellem Edit** (`onChange`), bzw. zum *Seeden* eines Initialwerts, wenn noch keiner existiert. Ein gescanntes Volumen (`roomVolume>0 && dimensions!=nil`) wird **nie** durch Defaults überschrieben.

**#1 — Decode-Fehler → stiller Leer-Default → nächstes Save zerstört gültige Daten.**
`SurfaceStore.loadSurfaces()` verschluckte Decode-Fehler und behielt das leere In-Memory-Default; die nächste Mutation re-encodierte das leere Array über den noch vorhandenen (nur unlesbaren) Blob → **permanenter Verlust** bei jeder Codable-Schema-Drift (z. B. neues Pflichtfeld in einem App-Update).
→ **Fix:** `canPersist`-Guard — `saveSurfaces()` **weigert sich**, über nicht-ladbare Daten zu schreiben; der unlesbare Blob wird nach `surfaceStore.corrupt` **gesichert** (für spätere Migration) statt still verloren.

## Sichere Klassen (vom Audit bestätigt, kein Fix nötig)
Getrennte UserDefaults-Keys (kein Cross-Store-Clobber), UUID-IDs (keine ID-Kollision), Import **merged** statt zu ersetzen, malformter XLSX/CSV-Import kann die Liste **nicht** zerstören (wirft vor Mutation), Koeffizienten werden auf [0,1] geklemmt.

## Verifikation — ehrlich
**App-Target-Änderungen → `ci-honest.yml` kompiliert sie NICHT** (App-Test-Target nicht verdrahtet, HANDOFF §10.2). Muss auf **macOS** verifiziert werden. Die vorhandenen (derzeit nicht laufenden) App-Tests decken `SurfaceStore` ab — sobald sie im CI-Gate sind, wird genau das automatisch geprüft. Logik von Hand durchgegangen; keine API-/Typ-Brüche (Optional-Tuple `!= nil` ok).

## Offen (dokumentiert, eigene Schritte)
MED-Funde aus demselben Audit: `clearAll()` beim Re-Scan verwirft Material-Zuweisungen ohne Rückfrage; Import ohne De-Dup; `MSHARCoordinator` mutiert `@Published` off-main; `MaterialEditorView` `id: \.name`. Alle in HANDOFF aufzunehmen, nicht in diesem PR.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_