### PR TITLE
Ehrliches Labeling: RT60 ist berechnet (Sabine), nicht gemessen

### DIFF
--- a/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60View.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60View.swift
@@ -31,6 +31,9 @@ struct RT60View: View {
                     .accessibilityHint("Reverberation time for this frequency")
                     .accessibilityIdentifier("rt60Row\(freq)")
                 }
+            } footer: {
+                Text("Berechnet nach Sabine aus Raumvolumen und Materialabsorption – keine akustische Messung.")
+                    .accessibilityIdentifier("rt60MethodNote")
             }
         }
         .navigationTitle("Nachhallzeiten")

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ConsolidatedPDFExporter.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ConsolidatedPDFExporter.swift
@@ -93,7 +93,7 @@ public class ConsolidatedPDFExporter {
             kCGPDFContextCreator: "AcoustiScan Consolidated Tool",
             kCGPDFContextAuthor: "MSH-Audio-Gruppe",
             kCGPDFContextTitle: "Gutachterlicher Raumakustik Report",
-            kCGPDFContextSubject: "RT60 Messung und DIN 18041 Bewertung"
+            kCGPDFContextSubject: "RT60 Berechnung (Sabine) und DIN 18041 Bewertung"
         ]
 
         let format = UIGraphicsPDFRendererFormat()
@@ -142,7 +142,7 @@ public class ConsolidatedPDFExporter {
         yPosition += 60
 
         // Subtitle
-        let subtitle = "RT60-Messung und DIN 18041-Bewertung"
+        let subtitle = "RT60-Berechnung (Sabine) und DIN 18041-Bewertung"
         let subtitleAttrs = PDFStyling.titleAttributes(size: 18, color: .darkGray)
         PDFStyling.draw(subtitle, at: CGPoint(x: margin, y: yPosition), attributes: subtitleAttrs)
         yPosition += 80
@@ -198,7 +198,7 @@ public class ConsolidatedPDFExporter {
 
         let metadataText = """
         Grunddaten:
-        - Messung durchgeführt am: \(data.date)
+        - Bericht erstellt am: \(data.date)
         - Raumtyp: \(data.roomType.displayName)
         - Raumvolumen: \(String(format: "%.2f", data.volume)) m³
         - Anzahl Oberflächenelemente: \(data.surfaces.count)
@@ -336,10 +336,11 @@ public class ConsolidatedPDFExporter {
         // Quality assurance statement
         yPosition += 40
         let qaStatement = """
-        Gutachterliche Bestätigung:
-        Diese Messung wurde nach DIN 18041 durchgeführt und entspricht den wissenschaftlichen Standards
-        für raumakustische Bewertungen. Die Empfehlungen basieren auf validierten akustischen Prinzipien
-        und dem 48-Parameter-Framework für umfassende Audiobewertung.
+        Hinweis zur Methodik:
+        Die RT60-Werte in diesem Bericht wurden nach der Sabine-Formel aus Raumvolumen und
+        Materialabsorption berechnet (Prognose), nicht akustisch gemessen. Die Bewertung
+        erfolgt nach DIN 18041:2016-03. Für eine messtechnische Abnahme ist eine
+        Impulsantwort-/Nachhallmessung nach ISO 3382 mit kalibriertem Mikrofon erforderlich.
         """
 
         let qaAttrs = PDFStyling.bodyAttributes(size: 12, color: .darkGray)

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportHTMLRenderer.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/ReportHTMLRenderer.swift
@@ -41,7 +41,7 @@ public class ReportHTMLRenderer {
         <body>
             <div class="header">
                 <h1>RT60 Bericht</h1>
-                <p>RT60-Messung und DIN 18041-Bewertung</p>
+                <p>RT60-Berechnung (Sabine) und DIN 18041-Bewertung</p>
             </div>
 
             \(renderMetadataSection(model.metadata))


### PR DESCRIPTION
## Ziel
Die einzige verbliebene **Unwahrheit** vor dem Fork beseitigen: Der Bericht/die App nannten die per **Sabine berechneten** RT60-Werte eine **„Messung"** — inklusive einer bedingungslosen „Gutachterlichen Bestätigung: Diese Messung wurde nach DIN 18041 durchgeführt". Web-Recherche (mit Quellen) bestätigt: RoomPlan/ARKit kann Nachhall **nicht messen**; eine Sabine-aus-Materialien-Prognose als „Messung" zu bezeichnen ist **nicht verteidigbar**.

## Geändert — nur nutzersichtbare Falsch-Claims (repo-weit gesweept)
- **`ConsolidatedPDFExporter`**: QA-Block sagt jetzt ehrlich, dass die Werte **nach Sabine berechnet** sind (Prognose), DIN 18041 zur Bewertung dient und für eine **messtechnische Abnahme** eine ISO-3382-Impulsantwort-/Nachhallmessung mit **kalibriertem Mikrofon** nötig ist. Untertitel + PDF-Subject → „RT60-Berechnung (Sabine)"; „Messung durchgeführt am" → „Bericht erstellt am".
- **`ReportHTMLRenderer`**: Kopf-Untertitel → „RT60-Berechnung (Sabine)".
- **`RT60View`** (App): Fußnote „Berechnet nach Sabine … keine akustische Messung."

## Bewusst NICHT angefasst (Scope-Disziplin — legitim, keine Falschaussage)
Typnamen `RT60Measurement`/`measuredRT60`, ISO/DIN-Doc-Kommentare, die `MeasurementQuality`-**Kalibrier-Infrastruktur** (für *echte* Messungen) und ungenutzte Localization-Keys. „Nur das Nötige, nicht mehr."

## Verifikation — ehrlich
Package-Dateien (`ConsolidatedPDFExporter`, `ReportHTMLRenderer`) → **`ci-honest.yml`** kompiliert/testet sie; keine Tests hingen an den alten Strings (geprüft). `RT60View` ist App-Code → **macOS-seitig** zu verifizieren (App-Test-Target nicht im CI).

## Kontext (Fork-Reife)
Letzter Substanz-Schritt vor dem Fork. Damit ist das Produkt beim Fork **wahrheitsgemäß** beschriftet — keine Peinlichkeit „nennt Prognose Messung". Größere Posten (echter Audio-Messpfad, App-Tests ins CI) bleiben bewusst out-of-scope und sind in HANDOFF dokumentiert.

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_