### PR TITLE
Docs: interaktiver HTML-Session-Substanzbericht

### DIFF
--- a/Docs/SESSION_REPORT.html
+++ b/Docs/SESSION_REPORT.html
@@ -1,0 +1,476 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>AcoustiScan — Session-Substanzbericht</title>
+<style>
+  :root{
+    --bg:#0b1020; --bg2:#121a33; --card:#161f3d; --card2:#1c274d;
+    --fg:#e8edff; --muted:#9aa6cc; --line:#27325c;
+    --acc:#5b8cff; --acc2:#19c3a3; --warn:#ffb020; --crit:#ff5c72; --ok:#3ddc84;
+    --pill:#22305c; --shadow:0 10px 30px rgba(0,0,0,.35);
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;font-family:-apple-system,system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+       background:linear-gradient(180deg,#0b1020,#0d1530 60%,#0b1020);color:var(--fg);line-height:1.55}
+  a{color:var(--acc);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,.mono{font-family:var(--mono);font-size:.86em}
+  .wrap{max-width:1180px;margin:0 auto;padding:0 22px}
+
+  /* Header */
+  header{padding:56px 0 28px;border-bottom:1px solid var(--line);
+         background:radial-gradient(1200px 400px at 70% -10%,rgba(91,140,255,.18),transparent)}
+  .eyebrow{color:var(--acc2);font-weight:700;letter-spacing:.14em;text-transform:uppercase;font-size:12px}
+  h1{font-size:clamp(28px,4vw,44px);margin:.25em 0 .15em;line-height:1.1}
+  .sub{color:var(--muted);font-size:18px;max-width:760px}
+  .meta{display:flex;flex-wrap:wrap;gap:10px;margin-top:20px}
+  .chip{background:var(--pill);border:1px solid var(--line);border-radius:999px;padding:6px 13px;font-size:13px;color:#cdd7ff}
+  .chip b{color:#fff}
+
+  /* Sticky nav */
+  nav.toc{position:sticky;top:0;z-index:20;background:rgba(11,16,32,.86);backdrop-filter:blur(10px);
+          border-bottom:1px solid var(--line)}
+  nav.toc .wrap{display:flex;gap:4px;overflow-x:auto;padding:10px 22px}
+  nav.toc a{white-space:nowrap;color:var(--muted);padding:8px 12px;border-radius:8px;font-size:14px;font-weight:600}
+  nav.toc a:hover{background:var(--card);color:#fff;text-decoration:none}
+
+  section{padding:46px 0;border-bottom:1px solid var(--line)}
+  h2{font-size:26px;margin:0 0 6px;display:flex;align-items:center;gap:10px}
+  h2 .num{color:var(--acc);font-family:var(--mono);font-size:18px}
+  .lead{color:var(--muted);max-width:820px;margin:0 0 22px}
+
+  .grid{display:grid;gap:16px}
+  .g2{grid-template-columns:repeat(2,1fr)}
+  .g3{grid-template-columns:repeat(3,1fr)}
+  .g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:820px){.g2,.g3,.g4{grid-template-columns:1fr}}
+
+  .card{background:linear-gradient(180deg,var(--card),var(--card2));border:1px solid var(--line);
+        border-radius:16px;padding:18px 18px;box-shadow:var(--shadow)}
+  .card h3{margin:.1em 0 .4em;font-size:17px}
+  .card p{margin:.2em 0;color:#cfd8ff}
+  .stat{font-size:34px;font-weight:800;background:linear-gradient(90deg,#7aa2ff,#19c3a3);-webkit-background-clip:text;background-clip:text;color:transparent}
+  .stat-l{color:var(--muted);font-size:13px;text-transform:uppercase;letter-spacing:.08em}
+
+  .sev{display:inline-block;font-size:11px;font-weight:800;letter-spacing:.05em;padding:3px 9px;border-radius:6px;text-transform:uppercase}
+  .crit{background:rgba(255,92,114,.16);color:#ff8a99;border:1px solid rgba(255,92,114,.4)}
+  .high{background:rgba(255,176,32,.15);color:#ffc658;border:1px solid rgba(255,176,32,.4)}
+  .med{background:rgba(91,140,255,.16);color:#9bb6ff;border:1px solid rgba(91,140,255,.4)}
+  .info{background:rgba(154,166,204,.14);color:#c2ccee;border:1px solid rgba(154,166,204,.35)}
+  .fixed{background:rgba(61,220,132,.15);color:#7ef0ab;border:1px solid rgba(61,220,132,.4)}
+  .open{background:rgba(255,176,32,.12);color:#ffce7a;border:1px solid rgba(255,176,32,.3)}
+
+  table{width:100%;border-collapse:collapse;font-size:14px;overflow:hidden;border-radius:12px}
+  th,td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{background:#0f1733;color:#aab6e0;font-size:12px;text-transform:uppercase;letter-spacing:.06em;position:sticky}
+  tbody tr:hover{background:rgba(91,140,255,.06)}
+  td.mono{font-family:var(--mono);font-size:12.5px;color:#bcd0ff}
+
+  details.fold{background:var(--card);border:1px solid var(--line);border-radius:12px;margin:10px 0;overflow:hidden}
+  details.fold>summary{cursor:pointer;padding:14px 16px;font-weight:700;list-style:none;display:flex;justify-content:space-between;align-items:center;gap:12px}
+  details.fold>summary::-webkit-details-marker{display:none}
+  details.fold>summary:after{content:"▸";color:var(--acc);transition:.2s}
+  details.fold[open]>summary:after{transform:rotate(90deg)}
+  details.fold .body{padding:0 16px 16px;color:#cfd8ff}
+
+  .timeline{position:relative;margin-left:8px;padding-left:26px;border-left:2px solid var(--line)}
+  .tl{position:relative;margin:0 0 18px}
+  .tl:before{content:"";position:absolute;left:-34px;top:4px;width:14px;height:14px;border-radius:50%;
+             background:var(--acc);box-shadow:0 0 0 4px rgba(91,140,255,.18)}
+  .tl.crit:before{background:var(--crit);box-shadow:0 0 0 4px rgba(255,92,114,.18)}
+  .tl.doc:before{background:var(--acc2);box-shadow:0 0 0 4px rgba(25,195,163,.18)}
+  .tl .pr{font-family:var(--mono);font-size:12px;color:var(--muted)}
+  .tl h4{margin:.1em 0 .2em;font-size:16px}
+
+  .tree{font-family:var(--mono);font-size:13px;color:#cdd8ff;background:#0c1430;border:1px solid var(--line);
+        border-radius:12px;padding:16px 18px;overflow:auto;line-height:1.7}
+  .tree .dir{color:#7aa2ff;font-weight:700}
+  .tree .tag{color:var(--muted)}
+  .tree .ok{color:var(--ok)} .tree .no{color:var(--crit)} .tree .warn{color:var(--warn)}
+
+  .flow{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:center;margin:6px 0}
+  .node{background:var(--card2);border:1px solid var(--line);border-radius:12px;padding:12px 14px;min-width:140px;text-align:center}
+  .node small{display:block;color:var(--muted);font-size:11px;margin-top:3px}
+  .node.acc{border-color:rgba(91,140,255,.5)} .node.eng{border-color:rgba(25,195,163,.5)}
+  .node.warnb{border-color:rgba(255,176,32,.5)}
+  .arrow{color:var(--acc);font-size:22px}
+
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin:8px 0 0;color:var(--muted);font-size:13px}
+  .legend span{display:inline-flex;align-items:center;gap:6px}
+  .dot{width:10px;height:10px;border-radius:50%;display:inline-block}
+
+  .callout{border-left:4px solid var(--acc);background:rgba(91,140,255,.08);padding:14px 16px;border-radius:0 10px 10px 0;margin:14px 0}
+  .callout.warn{border-color:var(--warn);background:rgba(255,176,32,.08)}
+  .callout.crit{border-color:var(--crit);background:rgba(255,92,114,.08)}
+  .callout.ok{border-color:var(--ok);background:rgba(61,220,132,.08)}
+
+  footer{padding:34px 0 60px;color:var(--muted);font-size:13px}
+  .kbd{font-family:var(--mono);background:#0c1430;border:1px solid var(--line);border-bottom-width:2px;border-radius:6px;padding:1px 6px;font-size:12px}
+  .muted{color:var(--muted)}
+  .pill-row{display:flex;flex-wrap:wrap;gap:8px;margin-top:8px}
+  .bar{height:9px;border-radius:6px;background:#0c1430;border:1px solid var(--line);overflow:hidden}
+  .bar > i{display:block;height:100%;background:linear-gradient(90deg,var(--acc),var(--acc2))}
+  .hl{color:#fff;font-weight:700}
+</style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <div class="eyebrow">AcoustiScan · iPadOS Raumakustik · Session-Substanzbericht</div>
+    <h1>Von „grün-gewaschen" zu <span class="hl">ehrlich&nbsp;verifizierbar</span></h1>
+    <p class="sub">Was in dieser Session am DIN-18041-RT60-Projekt wirklich passiert ist:
+       Architektur, Datenfluss, die echten Findings, die Fixes und der ehrliche Reifegrad für Fork &amp; macOS-Migration.</p>
+    <div class="meta">
+      <span class="chip"><b>13</b>&nbsp;PRs erstellt (#268–#280)</span>
+      <span class="chip"><b>3</b>&nbsp;Engine-Bugs · <b>2</b>&nbsp;Daten-Bugs · <b>1</b>&nbsp;Wahrheits-Fix</span>
+      <span class="chip"><b>5</b>&nbsp;Audit-Agenten</span>
+      <span class="chip">Stand <b>2026-05-30</b></span>
+      <span class="chip">Quelle: Repo + CI, nicht Usage-Statistik</span>
+    </div>
+  </div>
+</header>
+
+<nav class="toc">
+  <div class="wrap">
+    <a href="#tldr">Überblick</a>
+    <a href="#scope">Scope</a>
+    <a href="#arch">Architektur</a>
+    <a href="#flow">Datenfluss</a>
+    <a href="#deps">Abhängigkeiten</a>
+    <a href="#repo">Repo-Struktur</a>
+    <a href="#findings">Findings</a>
+    <a href="#milestones">Meilensteine</a>
+    <a href="#ci">CI &amp; Governance</a>
+    <a href="#handoff">Fork-Reife</a>
+  </div>
+</nav>
+
+<!-- ÜBERBLICK -->
+<section id="tldr"><div class="wrap">
+  <h2><span class="num">01</span> Überblick &amp; Kernaussage</h2>
+  <p class="lead">Ausgangslage: ein Repo, das Bots zuvor „grün gewaschen" hatten — maskierte Fehler, erfundene DIN-Werte, Schein-Tests.
+     Ziel dieser Session: <b>Substanz statt Politur</b> — echte Funktionen, keine Fakes, ehrlich dokumentiert, fork-bereit.</p>
+
+  <div class="grid g4">
+    <div class="card"><div class="stat-l">Rechenkern</div><div class="stat">✓</div><p>DIN&nbsp;18041 A1–A5 normtreu, getestet, CI-grün</p></div>
+    <div class="card"><div class="stat-l">Report-Wahrheit</div><div class="stat">✓</div><p>Keine erfundenen Sollwerte mehr; „berechnet" statt „gemessen"</p></div>
+    <div class="card"><div class="stat-l">Daten-Integrität</div><div class="stat">2→0</div><p>Zwei HIGH-Überschreibungs-Bugs behoben</p></div>
+    <div class="card"><div class="stat-l">App verifiziert?</div><div class="stat" style="background:linear-gradient(90deg,#ffb020,#ff5c72);-webkit-background-clip:text;background-clip:text;color:transparent">teilw.</div><p>App-Tests laufen in keiner CI — ehrlich dokumentiert</p></div>
+  </div>
+
+  <div class="callout crit" style="margin-top:18px">
+    <b>Der zentrale Fund (Produkt-Wahrheit):</b> Die App <b>misst RT60 nicht — sie prognostiziert es</b> (Sabine-Formel
+    aus Materialabsorption). Es gibt keinen Mikrofon-/Audio-Pfad; die echte Impulsantwort-Engine wird nie aufgerufen.
+    Web-Recherche bestätigt: RoomPlan/ARKit kann Nachhall nicht messen. → In dieser Session ehrlich umetikettiert (PR&nbsp;#280),
+    der echte Messpfad bleibt bewusst out-of-scope und ist dokumentiert.
+  </div>
+  <div class="callout ok">
+    <b>Aktualität bestätigt:</b> DIN&nbsp;18041:2016-03 ist 2026 weiterhin die gültige Edition (kein Nachfolger/Entwurf).
+    Die Engine darf so ausgeliefert werden. <span class="muted">(Quelle: dinmedia.de, baunormenlexikon.de — Web-Recherche)</span>
+  </div>
+</div></section>
+
+<!-- SCOPE -->
+<section id="scope"><div class="wrap">
+  <h2><span class="num">02</span> Scope — und warum er geschnitten wurde (EKS&nbsp;×&nbsp;Pareto)</h2>
+  <p class="lead">Die ehrliche Antwort auf „ist der Scope zu groß?": <b>Ja.</b> Per EKS (ein Engpass) und Pareto (20 % Aufwand → 80 % Wert,
+     <i>ohne Widerspruch hier ausführbar</i>) wurde getrennt, was <b>jetzt</b> Substanz bringt und was bewusst der macOS-Migration gehört.</p>
+  <div class="grid g2">
+    <div class="card">
+      <h3 style="color:var(--ok)">✓ In-Scope — erledigt &amp; hier verifizierbar</h3>
+      <ul>
+        <li>DIN-Engine normtreu (A1–A5, Bild-2-Band) <span class="sev fixed">CI</span></li>
+        <li>Report ohne erfundene Werte (M3) <span class="sev fixed">CI</span></li>
+        <li>Volumen-Gültigkeit (H2) &amp; 8000-Hz-Kennzeichnung (H1) <span class="sev fixed">CI</span></li>
+        <li>Daten-Überschreibung verhindert (2× HIGH) <span class="sev fixed">PR</span></li>
+        <li>Schein-Tests → echte Asserts <span class="sev fixed">CI</span></li>
+        <li>Ehrliches RT60-Labeling <span class="sev fixed">CI</span></li>
+        <li>Governance: echtes CODEOWNERS; LICENSE; Onboarding; HANDOFF §10/§11</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3 style="color:var(--warn)">◷ Out-of-Scope — dokumentiert für macOS/Owner</h3>
+      <ul>
+        <li>Echter Audio-Messpfad (Mikrofon + ISO 3382 + Schroeder) — großes Feature, gerätegebunden</li>
+        <li>App-Test-Target ins CI-Gate (<code>.pbxproj</code>-Chirurgie, nur auf Mac sicher)</li>
+        <li>Lint/Format-, Release/Archive-, Coverage-Gates in CI</li>
+        <li>ExportView verdrahten + asymmetrische Toleranz im App-Exporter</li>
+        <li>Modell-Duplikate App↔Package konsolidieren</li>
+        <li>4000-Hz-Bild-2-Toleranz gegen <i>gedruckte</i> Norm prüfen (nicht raten)</li>
+      </ul>
+    </div>
+  </div>
+  <div class="callout warn">
+    <b>Engpass-Prinzip (EKS):</b> Der eine Engpass ist „App-Tests laufen in keiner CI". Er ist aber <b>Mac-gebunden</b>
+    (diese Linux-Sandbox hat kein <code>swift</code>/<code>xcodebuild</code>). Ein Gate hier „blind" einzubauen würde
+    die Regel „kein Green-Washing" verletzen — deshalb dokumentiert statt vorgetäuscht.
+  </div>
+</div></section>
+
+<!-- ARCHITEKTUR -->
+<section id="arch"><div class="wrap">
+  <h2><span class="num">03</span> Architektur — der Backbone</h2>
+  <p class="lead">Drei Schichten, klare Trennung. Der <b>Rechenkern</b> ist plattformunabhängig (baut/test via <code>swift test</code>);
+     die <b>iOS-App</b> ist die SwiftUI-Oberfläche; ein separates <b>Export-Modul</b> rendert PDF/HTML.</p>
+
+  <div class="card">
+    <div class="flow">
+      <div class="node acc"><b>AcoustiScanApp</b><small>SwiftUI · iPadOS 17 · 28 Quelldateien</small></div>
+      <span class="arrow">→</span>
+      <div class="node eng"><b>AcoustiScanConsolidated</b><small>Swift Package · Engine · 26 Dateien</small></div>
+      <span class="arrow">→</span>
+      <div class="node"><b>Modules/Export</b><small>ReportExport · PDF/HTML/XLSX · 8 Dateien</small></div>
+    </div>
+    <div class="legend" style="justify-content:center">
+      <span><i class="dot" style="background:var(--acc)"></i> CI baut + testet (xcodebuild)</span>
+      <span><i class="dot" style="background:var(--acc2)"></i> CI baut + testet (swift test)</span>
+      <span><i class="dot" style="background:var(--warn)"></i> nicht im CI-Gate</span>
+    </div>
+  </div>
+
+  <div class="grid g3" style="margin-top:16px">
+    <div class="card"><h3>Engine-Kern <span class="sev fixed">getestet</span></h3>
+      <p><code>RT60Calculator</code> (Sabine), <code>DIN18041/</code> (Database + Evaluator),
+      <code>Models/RoomType</code> (A1–A5, <code>T_soll=a·lg(V)+b</code>),
+      <code>DIN18041Target</code> (asymm. Bild-2-Band), <code>ImpulseResponseAnalyzer</code> (Schroeder — echt, aber von der App ungenutzt).</p></div>
+    <div class="card"><h3>App-Schicht <span class="sev open">App-Tests nicht in CI</span></h3>
+      <p><code>SurfaceStore</code> (State + Persistenz), <code>MaterialManager</code> (DB + XLSX),
+      Views: <code>RT60</code>/<code>Scanner</code>/<code>Material</code>/<code>Export</code>,
+      eigener PDF-Stack (<code>PDF*Renderer</code>).</p></div>
+    <div class="card"><h3>Export-Modul <span class="sev fixed">getestet</span></h3>
+      <p><code>PDFReportRenderer</code> (UIKit/AppKit/Text), <code>ReportHTMLRenderer</code>,
+      Snapshot-/Contract-/Robustness-Tests. Vom App-Target <b>nicht</b> importiert (Dual-Stack — bewusst dokumentiert).</p></div>
+  </div>
+
+  <div class="callout warn"><b>Bekannte Tech-Debt (dokumentiert):</b> doppelte Modelle (App vs. Package),
+     Dual-Build-System (<code>.xcodeproj</code> ist maßgeblich; das parallele App-<code>Package.swift</code> baut die CI nicht).</div>
+</div></section>
+
+<!-- DATENFLUSS -->
+<section id="flow"><div class="wrap">
+  <h2><span class="num">04</span> Datenfluss — wie eine Zahl in den Report kommt</h2>
+  <p class="lead">Der reale Pfad heute. Wichtig für die Wahrheit: Der RT60-Wert entsteht aus <b>Geometrie × Materialabsorption</b> (Sabine),
+     nicht aus einer akustischen Messung.</p>
+
+  <div class="card">
+    <div class="flow">
+      <div class="node warnb">Raum-Geometrie<small>RoomPlan/LiDAR <i>oder</i> manuell — nur Volumen/Fläche</small></div>
+      <span class="arrow">→</span>
+      <div class="node">Flächen + Material<small>SurfaceStore · MaterialManager (α je Oktave)</small></div>
+      <span class="arrow">→</span>
+      <div class="node eng">RT60 = 0.161·V/A<small>Sabine — <b>Prognose</b>, keine Messung</small></div>
+    </div>
+    <div class="flow">
+      <span class="arrow">↓</span>
+    </div>
+    <div class="flow">
+      <div class="node eng">DIN-Bewertung<small>T_soll(A1–A5) + Bild-2-Band → within/zu hoch/zu tief</small></div>
+      <span class="arrow">→</span>
+      <div class="node">ReportModel<small>+ Validity-Flags (Volumen-Range, nicht bewertete Bänder)</small></div>
+      <span class="arrow">→</span>
+      <div class="node acc">PDF / HTML<small>echte T_soll · ehrliches Methodik-Label</small></div>
+    </div>
+  </div>
+
+  <div class="grid g3" style="margin-top:16px">
+    <div class="card"><h3>Vorher (gefährlich)</h3>
+      <p class="muted">8000 Hz fiel lautlos aus der Bewertung · out-of-range-Volumen lieferte still extrapolierten Sollwert ·
+      Report druckte erfundene 0.6/0.5/0.48 · „Messung durchgeführt".</p></div>
+    <div class="card"><h3>Nachher (ehrlich)</h3>
+      <p>8000 Hz „nicht bewertet n. DIN" · Volumen-Range im Report markiert · echte <code>din_targets</code> ·
+      „RT60 berechnet (Sabine), keine Messung".</p></div>
+    <div class="card"><h3>Schutz (neu)</h3>
+      <p>Gescanntes Volumen wird nicht durch manuelle Defaults überschrieben · <code>canPersist</code>-Guard +
+      <code>.corrupt</code>-Backup gegen stillen Datenverlust.</p></div>
+  </div>
+</div></section>
+
+<!-- ABHÄNGIGKEITEN -->
+<section id="deps"><div class="wrap">
+  <h2><span class="num">05</span> Abhängigkeiten</h2>
+  <div class="grid g2">
+    <div class="card"><h3>Intern</h3>
+      <table>
+        <tr><th>Von</th><th>nutzt</th></tr>
+        <tr><td class="mono">AcoustiScanApp</td><td class="mono">AcoustiScanConsolidated</td></tr>
+        <tr><td class="mono">Modules/Export</td><td class="mono">— (eigenständig, eigenes ReportModel)</td></tr>
+        <tr><td class="mono">AcoustiScanTool (CLI)</td><td class="mono">AcoustiScanConsolidated · SampleData (Demo)</td></tr>
+      </table>
+      <p class="muted" style="margin-top:8px">Ungenutzte <code>ReportExport</code>-Dependency wurde in dieser Sanierung entfernt (#265).</p>
+    </div>
+    <div class="card"><h3>Extern / Plattform</h3>
+      <ul>
+        <li><b>Apple RoomPlan / ARKit</b> — nur Geometrie (kein RT60)</li>
+        <li><b>PDFKit / UIKit / AppKit</b> — Report-Rendering (plattformbedingt)</li>
+        <li><b>CryptoKit</b> — Hash (mit Fallback)</li>
+        <li><b>Kein Netzwerk-Code, keine Telemetrie</b> — Security-Audit bestätigt</li>
+        <li>Toolchain: <b>Xcode 15.4</b> (CI gepinnt, iOS-17-SDK)</li>
+      </ul>
+    </div>
+  </div>
+</div></section>
+
+<!-- REPO -->
+<section id="repo"><div class="wrap">
+  <h2><span class="num">06</span> Repo-Struktur (vollständig)</h2>
+  <p class="lead">Top-Level und die wesentlichen Quellbäume. <span class="ok">✓</span> = von CI getestet ·
+     <span class="warn">◷</span> = existiert, aber nicht im CI-Gate · <span class="no">✗</span> = Platzhalter/offen.</p>
+  <div class="tree">
+<span class="dir">RT60_ipad_akusti-scan-APP/</span>
+├─ <span class="dir">AcoustiScanConsolidated/</span>            <span class="tag">Swift-Package · Engine</span> <span class="ok">✓ CI (swift test)</span>
+│  └─ Sources/AcoustiScanConsolidated/
+│     ├─ RT60Calculator.swift            <span class="tag">Sabine-Formel</span>
+│     ├─ <span class="dir">DIN18041/</span> Database, RT60Evaluator   <span class="tag">A1–A5 Bewertung</span>
+│     ├─ <span class="dir">Acoustics/</span> ImpulseResponseAnalyzer  <span class="tag">Schroeder — echt, App-ungenutzt</span>
+│     ├─ <span class="dir">Models/</span> RoomType, DIN18041Target, RT60Measurement, …  <span class="tag">(13)</span>
+│     ├─ ReportModel.swift               <span class="tag">+ Validity-Flags (H1/H2)</span>
+│     ├─ ReportHTMLRenderer.swift        <span class="tag">ehrliches Label (#280)</span>
+│     └─ ConsolidatedPDFExporter.swift   <span class="tag">Methodik-Hinweis (#280)</span>
+├─ <span class="dir">Modules/Export/</span>                       <span class="tag">ReportExport · PDF/HTML/XLSX</span> <span class="ok">✓ CI</span>
+│  ├─ Sources/ReportExport/ PDFReportRenderer, ReportHTMLRenderer  <span class="tag">Fakes entfernt (#273)</span>
+│  └─ Tests/ Contract, Robustness, Snapshot  <span class="tag">Schein-Tests → echt (#276)</span>
+├─ <span class="dir">AcoustiScanApp/</span>                       <span class="tag">iOS-App · SwiftUI</span> <span class="warn">◷ baut, App-Tests nicht in CI</span>
+│  ├─ App/ ContentView.swift             <span class="tag">TabView · Volumen-Schutz (#279)</span>
+│  ├─ Models/ SurfaceStore (Persistenz-Guard #279), MaterialManager, PDF*Renderer
+│  ├─ Views/ RT60 (Methodik-Fußnote #280), Scanner, Material, <span class="no">Export = Platzhalter</span>
+│  └─ AcoustiScanAppTests/               <span class="no">✗ nicht im Xcode-Projekt (0×)</span>
+├─ <span class="dir">.github/</span> workflows/ci-honest.yml      <span class="ok">✓ aktiv</span> · CODEOWNERS <span class="tag">real (#278)</span>
+├─ <span class="dir">Schemas/</span> report.schema.json, audit…  <span class="warn">◷ ungenutzt (nicht validiert)</span>
+├─ <span class="dir">Tools/</span> LogParser, linters, reporthtml  <span class="warn">◷ nicht im CI</span>
+├─ README · CONTRIBUTING · <b>HANDOFF</b> · CLAUDE.md · LICENSE · ONBOARDING_EXTERNAL
+  </div>
+</div></section>
+
+<!-- FINDINGS -->
+<section id="findings"><div class="wrap">
+  <h2><span class="num">07</span> Findings — gefunden, verifiziert, behoben</h2>
+  <p class="lead">Aus fünf Audit-Agenten (Code-Review, Fake-Funktionen, Daten-Integrität, Security, DIN-Aktualität) + eigener Inspektion.
+     Jeder Eintrag mit Datei-Beleg.</p>
+
+  <div class="legend" style="margin-bottom:10px">
+    <span><span class="sev crit">Critical</span> Falschaussage erreicht Ausgabe</span>
+    <span><span class="sev high">High</span> echter Bug / Datenverlust</span>
+    <span><span class="sev med">Med</span> latent / Folgeschritt</span>
+    <span><span class="sev fixed">behoben</span></span>
+    <span><span class="sev open">offen/dokumentiert</span></span>
+  </div>
+
+  <table>
+    <thead><tr><th>#</th><th>Befund</th><th>Beleg</th><th>Schwere</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td class="mono">CRIT</td><td><b>App misst RT60 nicht</b> — Sabine-Prognose als „Messung" deklariert; Audio-Engine nie aufgerufen</td><td class="mono">SurfaceStore.swift:104 · ConsolidatedPDFExporter:340</td><td><span class="sev crit">Critical</span></td><td><span class="sev fixed">Label #280</span></td></tr>
+      <tr><td class="mono">M3</td><td><b>Erfundene DIN-Sollwerte</b> (0.6/0.5/0.48, „Classroom/Office") überschreiben echte T_soll</td><td class="mono">PDFReportRenderer (4×) · ReportHTMLRenderer</td><td><span class="sev high">High</span></td><td><span class="sev fixed">#273</span></td></tr>
+      <tr><td class="mono">H2</td><td><b>Volumen-Gültigkeitsbereich nie geprüft</b> → out-of-range extrapoliert still falschen Sollwert</td><td class="mono">RoomType.validVolumeRange (ungenutzt)</td><td><span class="sev high">High</span></td><td><span class="sev fixed">#274</span></td></tr>
+      <tr><td class="mono">H1</td><td><b>8000-Hz-Band lautlos gedroppt</b> aus DIN-Bewertung; Konformität-% ignoriert es</td><td class="mono">RT60Calculator:32 vs evaluationFrequencies</td><td><span class="sev high">High</span></td><td><span class="sev fixed">#275</span></td></tr>
+      <tr><td class="mono">D2</td><td><b>Gescanntes Volumen überschrieben</b> durch manuelle Defaults bei jedem <code>.onAppear</code></td><td class="mono">ContentView.swift:75 syncRoomVolume</td><td><span class="sev high">High</span></td><td><span class="sev fixed">#279</span></td></tr>
+      <tr><td class="mono">D1</td><td><b>Stiller Datenverlust</b>: Decode-Fehler → leeres Default → nächstes Save clobbert gültigen Blob</td><td class="mono">SurfaceStore.loadSurfaces:159</td><td><span class="sev high">High</span></td><td><span class="sev fixed">#279</span></td></tr>
+      <tr><td class="mono">T1</td><td><b>Green-Washing-Tests</b>: <code>XCTAssertEqual(h,h)</code>, 2× <code>XCTAssertTrue(true)</code></td><td class="mono">PDFReportSnapshotTests:41 · u.a.</td><td><span class="sev med">Med</span></td><td><span class="sev fixed">#276</span></td></tr>
+      <tr><td class="mono">G1</td><td><b>CODEOWNERS Fake-Platzhalter</b> (@your-org/* existiert nicht) → erzwingt nichts</td><td class="mono">.github/CODEOWNERS</td><td><span class="sev med">Med</span></td><td><span class="sev fixed">#278</span></td></tr>
+      <tr><td class="mono">M1</td><td>App-PDF-Exporter nutzt <b>symmetrische</b> Toleranz statt asymm. Bild-2-Band</td><td class="mono">PDFTableRenderer:229 · PDFPageRenderer:358</td><td><span class="sev med">Med (latent)</span></td><td><span class="sev open">HANDOFF §10.5</span></td></tr>
+      <tr><td class="mono">M4</td><td>Paket-<code>AcousticMaterial</code> erfindet α=0.1 für fehlende Koeffizienten</td><td class="mono">Models/AcousticMaterial.swift:48</td><td><span class="sev med">Med</span></td><td><span class="sev open">HANDOFF §10.5</span></td></tr>
+      <tr><td class="mono">N1</td><td>4000-Hz-Toleranz evtl. asymmetrisch — exakte Bild-2-Zahlen nicht verbatim belegbar</td><td class="mono">RoomType.toleranceRatios:117</td><td><span class="sev med">Med</span></td><td><span class="sev open">gegen Norm prüfen</span></td></tr>
+      <tr><td class="mono">SEC</td><td><b>Security-Audit:</b> keine Secrets, kein Netzwerk, kein Telemetrie, Git-Historie sauber</td><td class="mono">ganzes Repo</td><td><span class="sev info">Info · GO</span></td><td><span class="sev fixed">1 UI-Setting offen</span></td></tr>
+    </tbody>
+  </table>
+
+  <details class="fold"><summary>Strukturell sicher (vom Daten-Audit bestätigt — kein Fix nötig)</summary>
+    <div class="body">
+      <ul>
+        <li>Getrennte UserDefaults-Keys (<code>customMaterials</code>, <code>surfaceStore</code>, <code>auditTrail</code>) → kein Cross-Store-Clobber</li>
+        <li>UUID-IDs überall → keine ID-Kollision</li>
+        <li>XLSX/CSV-Import <b>merged</b> statt zu ersetzen; malformter Import wirft <b>vor</b> Mutation → zerstört Liste nicht</li>
+        <li>Absorptionskoeffizienten auf [0,1] geklemmt</li>
+      </ul>
+    </div>
+  </details>
+</div></section>
+
+<!-- MEILENSTEINE -->
+<section id="milestones"><div class="wrap">
+  <h2><span class="num">08</span> Meilensteine (chronologisch)</h2>
+  <p class="lead">Jeder Punkt = ein fokussierter, CI-verifizierter PR. Reihenfolge nach EKS: erst Wahrheit/Korrektheit, dann Integrität, dann Übergabe.</p>
+  <div class="timeline">
+    <div class="tl"><div class="pr">#264 · gemergt</div><h4>DIN 18041 normtreu (A1–A5)</h4><p class="muted">Erfundene Formel ersetzt durch <code>T_soll=a·lg(V)+b</code> + asymmetrisches Bild-2-Band, mit Tests.</p></div>
+    <div class="tl"><div class="pr">#265–#272 · gemergt</div><h4>Cleanup, ehrliche Doku, LICENSE, CLAUDE.md</h4><p class="muted">README/CONTRIBUTING-Faktenfehler, proprietäre LICENSE + Onboarding, HANDOFF.md, Kontext-Datei für Claude-Instanzen.</p></div>
+    <div class="tl crit"><div class="pr">#273 · gemergt</div><h4>M3 — erfundene Sollwerte entfernt</h4><p class="muted">Report zeigt echte <code>din_targets</code>; vier Renderer-Pfade + HTML; Tests entzementiert. (Copilot fand HTML-Lücke → nachgezogen.)</p></div>
+    <div class="tl"><div class="pr">#274 · gemergt</div><h4>H2 — Volumen-Gültigkeit gekennzeichnet</h4></div>
+    <div class="tl"><div class="pr">#275 · gemergt</div><h4>H1 — 8000 Hz „nicht bewertet" statt still gedroppt</h4></div>
+    <div class="tl"><div class="pr">#276 · gemergt</div><h4>Schein-Tests durch echte Assertions ersetzt</h4></div>
+    <div class="tl doc"><div class="pr">#277 · gemergt</div><h4>HANDOFF §10 — Verifizierungs-Engpässe &amp; blinde Flecken</h4></div>
+    <div class="tl doc"><div class="pr">#278 · offen</div><h4>Governance — echtes CODEOWNERS + §11 Durchsetzung</h4></div>
+    <div class="tl crit"><div class="pr">#279 · offen</div><h4>Daten-Überschreibung verhindert (2× HIGH)</h4></div>
+    <div class="tl crit"><div class="pr">#280 · offen</div><h4>Ehrliches Labeling — RT60 ist berechnet, nicht gemessen</h4></div>
+  </div>
+</div></section>
+
+<!-- CI & GOVERNANCE -->
+<section id="ci"><div class="wrap">
+  <h2><span class="num">09</span> CI, Governance &amp; Systemdurchsetzung</h2>
+  <div class="grid g2">
+    <div class="card"><h3>Was die CI <span class="ok">wirklich</span> tut</h3>
+      <ul>
+        <li><code>ci-honest.yml</code> triggert auto (push/PR) — <b>keine</b> Fehler-Maskierung</li>
+        <li>Job 1: <code>swift test</code> für <b>Consolidated</b> + <b>Export</b></li>
+        <li>Job 2: <code>xcodebuild build</code> der App (Simulator-SDK, <b>ohne</b> <code>test</code>)</li>
+        <li>Bei Fehler: echter Build-Tail als PR-Kommentar</li>
+        <li>Alle Masking-Workflows (self-healing, auto-retry, …) stillgelegt</li>
+      </ul>
+    </div>
+    <div class="card"><h3>Durchsetzung — nur der Owner kann das</h3>
+      <ul>
+        <li>Branch-Protection auf <code>main</code> + die <b>2 ci-honest-Jobs</b> als <i>required</i></li>
+        <li>„Require review from Code Owners" (CODEOWNERS jetzt real)</li>
+        <li>Fork-Actions: read-only + Approval für Outside-Collaborators</li>
+      </ul>
+      <div class="callout warn" style="margin-top:10px">Status dieser drei Schalter ist <b>aus der Sandbox nicht prüfbar</b> — im GitHub-UI verifizieren (HANDOFF §11).</div>
+    </div>
+  </div>
+  <div class="card" style="margin-top:16px">
+    <h3>Verifizierungs-Abdeckung (qualitativ)</h3>
+    <div style="display:grid;gap:10px">
+      <div><div class="stat-l">Engine (RT60/DIN/Impulsantwort)</div><div class="bar"><i style="width:92%"></i></div></div>
+      <div><div class="stat-l">Report-Rendering (PDF/HTML)</div><div class="bar"><i style="width:70%"></i></div></div>
+      <div><div class="stat-l">App-Logik (Store/Material/XLSX) — Tests existieren, laufen aber nicht</div><div class="bar"><i style="width:18%;background:linear-gradient(90deg,#ffb020,#ff5c72)"></i></div></div>
+      <div><div class="stat-l">Audio-Messung / LiDAR / Persistenz auf Gerät</div><div class="bar"><i style="width:4%;background:#ff5c72"></i></div></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- FORK-REIFE -->
+<section id="handoff"><div class="wrap">
+  <h2><span class="num">10</span> Fork-Reife &amp; macOS-Migration</h2>
+  <p class="lead">Ehrlicher Reifegrad für die Übergabe an einen externen Entwickler — ohne Peinlichkeiten, weil <b>transparent</b>.</p>
+  <div class="grid g2">
+    <div class="card"><h3 style="color:var(--ok)">Steht für den Fork</h3>
+      <ul>
+        <li>Rechenkern substanziell, normtreu, getestet, CI-grün</li>
+        <li>Keine Falschbehauptungen mehr in Report/App</li>
+        <li>Daten-Integrität: reale Clobber-Bugs behoben</li>
+        <li>Konsistente Doku: README · CONTRIBUTING · HANDOFF · CLAUDE.md · LICENSE · ONBOARDING</li>
+        <li>Security-GO (keine Secrets/Netzwerk/Telemetrie)</li>
+      </ul>
+    </div>
+    <div class="card"><h3 style="color:var(--acc)">Erste Schritte auf dem Mac</h3>
+      <ol>
+        <li><code>swift test</code> (Consolidated + Export) → echtes Rot/Grün</li>
+        <li><code>xcodebuild build</code> der App (Simulator)</li>
+        <li>App-Test-Target in Xcode anlegen → <code>xcodebuild test</code> ins CI (Engpass schließen)</li>
+        <li>Branch-Protection + required checks aktivieren (HANDOFF §11)</li>
+        <li>Entscheidung Critical: echten Audio-Messpfad bauen <i>oder</i> dauerhaft als „Prognose" labeln</li>
+      </ol>
+    </div>
+  </div>
+  <div class="callout ok"><b>Leitregel (in CLAUDE.md verankert):</b> Das Wort „verifiziert" nur verwenden, wenn wirklich gebaut/gelaufen — nicht für „sieht gut aus".</div>
+</div></section>
+
+<footer><div class="wrap">
+  <p><b>AcoustiScan Session-Substanzbericht</b> · generiert 2026-05-30 · Quelle: Repository-Stand &amp; CI-Läufe, nicht Usage-Statistik.</p>
+  <p class="muted">Maßgeblich bei Abweichungen: der Code und <code>HANDOFF.md</code>. Schweregrade folgen dem Audit (Critical → Info).
+     Mac-gebundene Punkte sind als solche gekennzeichnet und in dieser Linux-Umgebung bewusst nicht „verifiziert".</p>
+</div></footer>
+</body>
+</html>


### PR DESCRIPTION
## Ziel
Ein **eigenständiger, interaktiver HTML-Bericht** (`Docs/SESSION_REPORT.html`), der die **Substanz** dieser Session festhält — nicht Usage-Statistik, sondern Architektur, Datenfluss, Findings und Reifegrad. Als Teil der Übergabe versioniert.

## Inhalt (10 Sektionen, sticky-Navigation, offline/kein externes JS-CSS)
- **Überblick** mit dem zentralen Wahrheits-Fund (App prognostiziert RT60, misst nicht) + Aktualitäts-Bestätigung (DIN 2016-03 gültig)
- **Scope** (EKS × Pareto: in-scope vs. bewusst Mac/Owner)
- **Architektur / Backbone** (3 Schichten, CI-Abdeckung farbcodiert)
- **Datenfluss** (wie eine Zahl in den Report kommt — Geometrie × Absorption → Sabine → DIN → PDF/HTML)
- **Abhängigkeiten** (intern + extern/Plattform)
- **Repo-Struktur** (vollständiger Baum mit ✓/◷/✗-Markern)
- **Findings-Tabelle** (Critical→Info, jeweils Datei-Beleg + Status/PR)
- **Meilensteine** (#264–#280, Timeline)
- **CI / Governance / Durchsetzung** (inkl. Verifizierungs-Balken)
- **Fork-Reife & macOS-Migration** (erste Schritte)

Alle Zahlen/Pfade aus dem realen Repo-Stand + CI-Historie gezogen.

## Risiko
Keines (eine HTML-Doku-Datei unter `Docs/`).

https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123iYgXWjYsUg623pDpCbmn)_