### PR TITLE
Audio-Impulsmessung: Aufnahme → Impulsantwort → RT60 → Vergleich mit Sabine

### DIFF
--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
@@ -16,8 +16,8 @@
 // permission APIs leaking into the cross-platform package).
 
 #if os(iOS)
+import Foundation
 import AVFoundation
-
 /// Records a short mono signal from the microphone and computes octave-band
 /// RT60 via `ImpulseCaptureProcessing` + `ImpulseResponseAnalyzer`.
 public final class AudioImpulseRecorder {

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
@@ -59,10 +59,13 @@ public final class AudioImpulseRecorder {
             throw RecorderError.engineFailure(error.localizedDescription)
         }
 
-        try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+        defer {
+            input.removeTap(onBus: 0)
+            engine.stop()
+        }
 
-        input.removeTap(onBus: 0)
-        engine.stop()
+        let nanoseconds = UInt64(max(0, duration) * 1_000_000_000)
+        try await Task.sleep(nanoseconds: nanoseconds)
 
         lock.lock()
         let samples = collected

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/AudioImpulseRecorder.swift
@@ -1,0 +1,94 @@
+// AudioImpulseRecorder.swift
+// AcoustiScan
+//
+// Microphone capture for an impulsive excitation (hand clap / balloon pop),
+// feeding the recorded signal into `ImpulseCaptureProcessing` for octave-band
+// RT60. This is the audio INPUT that was previously missing entirely.
+//
+// VERIFICATION STATUS: iOS-only; compile-checked by the iOS app build (the app
+// links AcoustiScanConsolidated, so this whole library is compiled for the
+// simulator). It is NOT unit-tested — there is no headless microphone in CI.
+// The testable signal processing lives in `ImpulseCaptureProcessing`.
+//
+// Runtime requirements (device): `NSMicrophoneUsageDescription` in the app's
+// Info.plist and a granted record permission. Requesting permission is the
+// responsibility of the app layer (kept out here to avoid OS-version-specific
+// permission APIs leaking into the cross-platform package).
+
+#if os(iOS)
+import AVFoundation
+
+/// Records a short mono signal from the microphone and computes octave-band
+/// RT60 via `ImpulseCaptureProcessing` + `ImpulseResponseAnalyzer`.
+public final class AudioImpulseRecorder {
+
+    public enum RecorderError: Error {
+        case engineFailure(String)
+        case sessionFailure(String)
+    }
+
+    private let engine = AVAudioEngine()
+
+    public init() {}
+
+    /// Capture `duration` seconds of mono audio.
+    /// - Returns: raw samples and the hardware sample rate (Hz).
+    public func record(duration: TimeInterval = 3.0) async throws -> (samples: [Float], sampleRate: Double) {
+        try configureSession()
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        let sampleRate = format.sampleRate
+
+        var collected: [Float] = []
+        let lock = NSLock()
+
+        input.installTap(onBus: 0, bufferSize: 4096, format: format) { buffer, _ in
+            guard let channel = buffer.floatChannelData?[0] else { return }
+            let frameCount = Int(buffer.frameLength)
+            lock.lock()
+            collected.append(contentsOf: UnsafeBufferPointer(start: channel, count: frameCount))
+            lock.unlock()
+        }
+
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            input.removeTap(onBus: 0)
+            throw RecorderError.engineFailure(error.localizedDescription)
+        }
+
+        try await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+
+        input.removeTap(onBus: 0)
+        engine.stop()
+
+        lock.lock()
+        let samples = collected
+        lock.unlock()
+        return (samples, sampleRate)
+    }
+
+    /// Convenience: record, then compute octave-band RT60 from the recording.
+    public func measureRT60(duration: TimeInterval = 3.0,
+                            minimumSNRdB: Double = 0.0) async throws -> [RT60Measurement] {
+        let (samples, sampleRate) = try await record(duration: duration)
+        return try ImpulseCaptureProcessing.measureRT60(
+            fromRecording: samples,
+            sampleRate: sampleRate,
+            minimumSNRdB: minimumSNRdB
+        )
+    }
+
+    private func configureSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.record, mode: .measurement, options: [])
+            try session.setActive(true)
+        } catch {
+            throw RecorderError.sessionFailure(error.localizedDescription)
+        }
+    }
+}
+#endif

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
@@ -1,0 +1,138 @@
+// ImpulseCaptureProcessing.swift
+// AcoustiScan
+//
+// The missing link between a microphone RECORDING and the (already tested)
+// Schroeder/RT60 DSP in `ImpulseResponseAnalyzer`:
+//   raw recording  ->  impulse response  ->  octave-band RT60  ->  vs. Sabine
+//
+// Method: impulse excitation (hand clap / balloon pop). We locate the impulse
+// onset (largest absolute amplitude), trim the pre-roll, and hand the decay to
+// `ImpulseResponseAnalyzer.rt60PerOctaveBand`.
+//
+// Verification: every function here is pure ([Float] in, value out) and covered
+// by unit tests (`ImpulseCaptureProcessingTests`). The audio I/O itself lives in
+// `AudioImpulseRecorder` (iOS only) and is compile-checked by the iOS app build,
+// but requires a real device + microphone to run.
+
+import Foundation
+
+/// Pure signal processing that turns a raw recording into a usable room impulse
+/// response and an octave-band RT60 result, plus a comparison against a
+/// (Sabine-)predicted RT60 so the prediction can VERIFY the measurement.
+public enum ImpulseCaptureProcessing {
+
+    public enum ProcessingError: Error, Equatable {
+        case emptyRecording
+        case noOnsetFound
+        case insufficientSNR(Double)
+    }
+
+    /// Index of the impulse onset = the sample with the largest absolute amplitude.
+    /// - Returns: onset index, or `nil` if the recording is empty / all zero.
+    public static func onsetIndex(in samples: [Float]) -> Int? {
+        guard !samples.isEmpty else { return nil }
+        var bestIndex = 0
+        var bestValue: Float = -1
+        for (i, sample) in samples.enumerated() {
+            let magnitude = abs(sample)
+            if magnitude > bestValue {
+                bestValue = magnitude
+                bestIndex = i
+            }
+        }
+        return bestValue > 0 ? bestIndex : nil
+    }
+
+    /// Extract the impulse response: keep a short pre-roll before the onset and
+    /// everything after it (the decay tail).
+    /// - Throws: `ProcessingError`/`AnalysisError` for empty input or bad sample rate.
+    public static func extractImpulseResponse(
+        from samples: [Float],
+        sampleRate: Double,
+        preRollSeconds: Double = 0.005
+    ) throws -> [Float] {
+        guard !samples.isEmpty else { throw ProcessingError.emptyRecording }
+        guard sampleRate > 0 else {
+            throw ImpulseResponseAnalyzer.AnalysisError.invalidSampleRate(sampleRate)
+        }
+        guard let onset = onsetIndex(in: samples) else { throw ProcessingError.noOnsetFound }
+
+        let preRoll = max(0, Int(preRollSeconds * sampleRate))
+        let start = max(0, onset - preRoll)
+        return Array(samples[start...])
+    }
+
+    /// Estimate signal-to-noise ratio (dB): onset peak vs. RMS of the pre-onset
+    /// segment (treated as background noise). Returns `nil` if no usable noise
+    /// segment exists (e.g. onset at the very start or perfect silence).
+    public static func estimateSNRdB(samples: [Float], sampleRate: Double) -> Double? {
+        guard let onset = onsetIndex(in: samples), onset > 1 else { return nil }
+        let noise = samples[0..<onset]
+        let peak = abs(samples[onset])
+        guard peak > 0 else { return nil }
+        let meanSquare = noise.reduce(0.0) { $0 + Double($1) * Double($1) } / Double(noise.count)
+        let noiseRMS = meanSquare.squareRoot()
+        guard noiseRMS > 0 else { return nil }
+        return 20.0 * log10(Double(peak) / noiseRMS)
+    }
+
+    /// Full pipeline: recording -> impulse response -> per-octave-band RT60.
+    /// - Parameter minimumSNRdB: if > 0 and the estimated SNR is below it, throws
+    ///   `insufficientSNR` instead of returning an unreliable result.
+    public static func measureRT60(
+        fromRecording samples: [Float],
+        sampleRate: Double,
+        minimumSNRdB: Double = 0.0
+    ) throws -> [RT60Measurement] {
+        if minimumSNRdB > 0,
+           let snr = estimateSNRdB(samples: samples, sampleRate: sampleRate),
+           snr < minimumSNRdB {
+            throw ProcessingError.insufficientSNR(snr)
+        }
+        let ir = try extractImpulseResponse(from: samples, sampleRate: sampleRate)
+        let byBand = try ImpulseResponseAnalyzer.rt60PerOctaveBand(ir: ir, sampleRate: sampleRate)
+        return byBand
+            .sorted { $0.key < $1.key }
+            .map { RT60Measurement(frequency: $0.key, rt60: $0.value) }
+    }
+
+    // MARK: - Measured vs. predicted (Sabine as verification)
+
+    /// One frequency band: measured RT60 vs. predicted (Sabine) RT60.
+    public struct RT60Comparison: Equatable {
+        public let frequency: Int
+        public let measured: Double
+        public let predicted: Double
+
+        public init(frequency: Int, measured: Double, predicted: Double) {
+            self.frequency = frequency
+            self.measured = measured
+            self.predicted = predicted
+        }
+
+        /// Absolute deviation in seconds (measured − predicted).
+        public var deltaSeconds: Double { measured - predicted }
+
+        /// Relative deviation (measured − predicted) / predicted; 0 if predicted == 0.
+        public var relativeError: Double {
+            predicted != 0 ? (measured - predicted) / predicted : 0
+        }
+    }
+
+    /// Compare a measured RT60 spectrum against a predicted (Sabine) one,
+    /// matched by frequency. Bands without a prediction are dropped.
+    public static func compare(
+        measured: [RT60Measurement],
+        predicted: [RT60Measurement]
+    ) -> [RT60Comparison] {
+        let predictedByFrequency = Dictionary(
+            predicted.map { ($0.frequency, $0.rt60) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        return measured.compactMap { m in
+            guard let p = predictedByFrequency[m.frequency] else { return nil }
+            return RT60Comparison(frequency: m.frequency, measured: m.rt60, predicted: p)
+        }
+        .sorted { $0.frequency < $1.frequency }
+    }
+}

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
@@ -24,6 +24,7 @@ public enum ImpulseCaptureProcessing {
     public enum ProcessingError: Error, Equatable {
         case emptyRecording
         case noOnsetFound
+        case snrUnavailable
         case insufficientSNR(Double)
     }
 

--- a/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
+++ b/AcoustiScanConsolidated/Sources/AcoustiScanConsolidated/Acoustics/ImpulseCaptureProcessing.swift
@@ -84,10 +84,13 @@ public enum ImpulseCaptureProcessing {
         sampleRate: Double,
         minimumSNRdB: Double = 0.0
     ) throws -> [RT60Measurement] {
-        if minimumSNRdB > 0,
-           let snr = estimateSNRdB(samples: samples, sampleRate: sampleRate),
-           snr < minimumSNRdB {
-            throw ProcessingError.insufficientSNR(snr)
+        if minimumSNRdB > 0 {
+            guard let snr = estimateSNRdB(samples: samples, sampleRate: sampleRate) else {
+                throw ProcessingError.snrUnavailable
+            }
+            if snr < minimumSNRdB {
+                throw ProcessingError.insufficientSNR(snr)
+            }
         }
         let ir = try extractImpulseResponse(from: samples, sampleRate: sampleRate)
         let byBand = try ImpulseResponseAnalyzer.rt60PerOctaveBand(ir: ir, sampleRate: sampleRate)

--- a/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/ImpulseCaptureProcessingTests.swift
+++ b/AcoustiScanConsolidated/Tests/AcoustiScanConsolidatedTests/ImpulseCaptureProcessingTests.swift
@@ -1,0 +1,161 @@
+// ImpulseCaptureProcessingTests.swift
+// Verifies the recording -> impulse response -> RT60 -> vs-Sabine pipeline.
+// (The AVFoundation capture itself is iOS-only and compile-checked by the app
+//  build; here we test the pure processing with synthetic signals.)
+
+import XCTest
+import Foundation
+@testable import AcoustiScanConsolidated
+
+final class ImpulseCaptureProcessingTests: XCTestCase {
+
+    /// Build a synthetic recording: `leadingSilence` zero samples, then an
+    /// exponentially decaying impulse with the given RT60.
+    private func syntheticRecording(
+        rt60: Double,
+        sampleRate: Double,
+        decaySeconds: Double,
+        leadingSilence: Int,
+        noiseAmplitude: Float = 0.0
+    ) -> [Float] {
+        var samples = [Float](repeating: 0.0, count: leadingSilence)
+        if noiseAmplitude > 0 {
+            for i in 0..<leadingSilence {
+                samples[i] = (i % 2 == 0 ? noiseAmplitude : -noiseAmplitude)
+            }
+        }
+        let n = Int(sampleRate * decaySeconds)
+        let decay = (0..<n).map { i -> Float in
+            let t = Double(i) / sampleRate
+            return Float(exp(-6.91 * t / rt60))
+        }
+        return samples + decay
+    }
+
+    // MARK: - Onset detection
+
+    func testOnsetIndexFindsImpulseAfterSilence() {
+        let recording = syntheticRecording(
+            rt60: 0.8, sampleRate: 48000, decaySeconds: 0.5, leadingSilence: 100
+        )
+        XCTAssertEqual(ImpulseCaptureProcessing.onsetIndex(in: recording), 100)
+    }
+
+    func testOnsetIndexNilForAllZero() {
+        XCTAssertNil(ImpulseCaptureProcessing.onsetIndex(in: [Float](repeating: 0, count: 50)))
+        XCTAssertNil(ImpulseCaptureProcessing.onsetIndex(in: []))
+    }
+
+    // MARK: - Extraction
+
+    func testExtractTrimsLeadingSilenceToPreRoll() throws {
+        let sampleRate = 48000.0
+        let leadingSilence = 2000 // > pre-roll
+        let recording = syntheticRecording(
+            rt60: 0.8, sampleRate: sampleRate, decaySeconds: 1.0, leadingSilence: leadingSilence
+        )
+        let ir = try ImpulseCaptureProcessing.extractImpulseResponse(
+            from: recording, sampleRate: sampleRate, preRollSeconds: 0.005
+        )
+        let preRoll = Int(0.005 * sampleRate) // 240 samples
+        XCTAssertEqual(ir.count, recording.count - (leadingSilence - preRoll))
+    }
+
+    func testExtractEmptyThrows() {
+        XCTAssertThrowsError(
+            try ImpulseCaptureProcessing.extractImpulseResponse(from: [], sampleRate: 48000)
+        )
+    }
+
+    func testExtractInvalidSampleRateThrows() {
+        XCTAssertThrowsError(
+            try ImpulseCaptureProcessing.extractImpulseResponse(from: [1, 0.5, 0.25], sampleRate: 0)
+        )
+    }
+
+    // MARK: - End-to-end RT60 (full band, tight tolerance)
+
+    func testEndToEndRecoversKnownRT60FullBand() throws {
+        let sampleRate = 48000.0
+        let targetRT60 = 0.8
+        let recording = syntheticRecording(
+            rt60: targetRT60, sampleRate: sampleRate, decaySeconds: 2.0, leadingSilence: 1500
+        )
+        let ir = try ImpulseCaptureProcessing.extractImpulseResponse(
+            from: recording, sampleRate: sampleRate
+        )
+        let rt60 = try ImpulseResponseAnalyzer.rt60(ir: ir, sampleRate: sampleRate)
+        XCTAssertNotNil(rt60)
+        XCTAssertEqual(rt60 ?? -1, targetRT60, accuracy: targetRT60 * 0.1)
+    }
+
+    // MARK: - Full octave-band pipeline
+
+    func testMeasureRT60ReturnsPlausibleBands() throws {
+        let sampleRate = 48000.0
+        let recording = syntheticRecording(
+            rt60: 0.8, sampleRate: sampleRate, decaySeconds: 2.0, leadingSilence: 500
+        )
+        let measured = try ImpulseCaptureProcessing.measureRT60(
+            fromRecording: recording, sampleRate: sampleRate
+        )
+        XCTAssertFalse(measured.isEmpty)
+        let standard: Set<Int> = [125, 250, 500, 1000, 2000, 4000, 8000]
+        for m in measured {
+            XCTAssertTrue(standard.contains(m.frequency))
+            XCTAssertGreaterThan(m.rt60, 0.0)
+            XCTAssertLessThan(m.rt60, 10.0)
+        }
+        // Results are sorted ascending by frequency.
+        XCTAssertEqual(measured.map(\.frequency), measured.map(\.frequency).sorted())
+    }
+
+    func testMeasureRT60EmptyRecordingThrows() {
+        XCTAssertThrowsError(
+            try ImpulseCaptureProcessing.measureRT60(fromRecording: [], sampleRate: 48000)
+        )
+    }
+
+    // MARK: - SNR
+
+    func testSNREstimateHighForCleanImpulse() {
+        let sampleRate = 48000.0
+        let recording = syntheticRecording(
+            rt60: 0.8, sampleRate: sampleRate, decaySeconds: 0.5,
+            leadingSilence: 1000, noiseAmplitude: 0.001
+        )
+        let snr = ImpulseCaptureProcessing.estimateSNRdB(samples: recording, sampleRate: sampleRate)
+        XCTAssertNotNil(snr)
+        XCTAssertGreaterThan(snr ?? 0, 40.0) // peak 1.0 vs noise ~0.001 -> ~60 dB
+    }
+
+    func testSNRNilWhenNoNoiseSegment() {
+        // Pure silence then impulse -> noise RMS is zero -> nil.
+        let recording = syntheticRecording(
+            rt60: 0.8, sampleRate: 48000, decaySeconds: 0.5, leadingSilence: 500
+        )
+        XCTAssertNil(ImpulseCaptureProcessing.estimateSNRdB(samples: recording, sampleRate: 48000))
+    }
+
+    // MARK: - Measured vs. predicted (Sabine as verification)
+
+    func testCompareMatchesByFrequency() {
+        let measured = [
+            RT60Measurement(frequency: 500, rt60: 0.90),
+            RT60Measurement(frequency: 1000, rt60: 0.80),
+            RT60Measurement(frequency: 2000, rt60: 0.70)
+        ]
+        let predicted = [
+            RT60Measurement(frequency: 500, rt60: 1.00),
+            RT60Measurement(frequency: 1000, rt60: 0.80)
+            // 2000 Hz intentionally missing -> dropped
+        ]
+        let comparison = ImpulseCaptureProcessing.compare(measured: measured, predicted: predicted)
+        XCTAssertEqual(comparison.count, 2)
+        XCTAssertEqual(comparison[0].frequency, 500)
+        XCTAssertEqual(comparison[0].deltaSeconds, -0.10, accuracy: 1e-9)
+        XCTAssertEqual(comparison[0].relativeError, -0.10, accuracy: 1e-9)
+        XCTAssertEqual(comparison[1].frequency, 1000)
+        XCTAssertEqual(comparison[1].deltaSeconds, 0.0, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Was (echter Code, keine Doku)
Schließt die **tatsächlich fehlende** Lücke aus der Code-Analyse: **es gab keinen Audio-Input** für die RT60-Messung. Der DSP-Mess-Kern (`ImpulseResponseAnalyzer`: Schroeder, Oktav-Biquad, `rt60PerOctaveBand`) war bereits vorhanden **und** in `AcousticsTests` umfangreich getestet — was fehlte, war **Aufnahme → Impulsantwort → RT60 → Vergleich mit Sabine**.

## Dateien
- **`Acoustics/ImpulseCaptureProcessing.swift`** — pure, getestete Logik: Onset-Erkennung, IR-Extraktion (Pre-Roll-Trim), SNR-Schätzung, `measureRT60(fromRecording:)`-Pipeline, und `compare(measured:predicted:)` → **Sabine-Prognose als Verifikation der Messung** (`RT60Comparison`).
- **`Acoustics/AudioImpulseRecorder.swift`** — `#if os(iOS)` AVAudioEngine-Mikrofon-Capture → Pipeline.
- **`Tests/.../ImpulseCaptureProcessingTests.swift`** — synthetische Aufnahme → RT60 (±10 %), Onset/Extract/SNR/Vergleich, Fehlerfälle.

## Verifikationsstatus (ehrlich, gemäß FORK_READINESS.md)
- ✅ **Verifizierbar in CI:** `ImpulseCaptureProcessing` + Tests laufen via `swift test` (macOS-Job). „Grün = echte Funktion" (synthetische IR → bekannte RT60).
- ⚙️ **Nur compile-gecheckt:** `AudioImpulseRecorder` (iOS-only) wird vom iOS-App-Build kompiliert, aber **nicht** ausgeführt — **Laufzeit braucht ein Gerät + Mikrofon** (und `NSMicrophoneUsageDescription` + Permission im App-Layer).
- ❌ **Noch offen (nächster Schritt):** UI-Anbindung in der App (Mess-Button/Screen) + Permission-Handling + echter Geräte-Test. Bewusst NICHT in diesem PR, um nichts Unausführbares als „fertig" zu verkaufen.

## Grenzen
Ich kann hier (Linux, kein `swift`/`xcodebuild`) nicht selbst bauen — die CI ist der Compiler. Falls ein Job rot wird, fixe ich nach.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBWACSFXfR1uYfiGJS5xFa)_