### PR TITLE
App-DIN-18041-Bewertung verdrahten (Kernfunktion: RoomType-Auswahl + Bewertung)

### DIFF
--- a/AcoustiScanApp/AcoustiScanApp.xcodeproj/project.pbxproj
+++ b/AcoustiScanApp/AcoustiScanApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D6B87FD3F6CF6BF3C82F0DA /* DINEvaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E189FB36B03E227642869FB6 /* DINEvaluation.swift */; };
 		2C6E06781844639C104E8907 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CF3E0E84C35284144BB3226E /* Localizable.strings */; };
 		52A23908CB3563EACF2067FB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C844B7827888F3E31637EECC /* Foundation.framework */; };
 		635F5DA43922D1A59793D4D2 /* MaterialManagerXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91BC90510829E31A2952D24 /* MaterialManagerXLSXTests.swift */; };
@@ -26,6 +27,7 @@
 		AA0000000000000000000013 /* MaterialEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000013 /* MaterialEditorView.swift */; };
 		AA0000000000000000000014 /* RT60MeasurementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000014 /* RT60MeasurementView.swift */; };
 		AS0000000000000000000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AR0000000000000000000001 /* Assets.xcassets */; };
+		C5B9B53320E1010BD7ABEF87 /* RT60DINView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24EF1F80CC20877CD865DA9 /* RT60DINView.swift */; };
 		C82BEF775D2EA984F1FA66B9 /* ErrorLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9975929754D1C31D0C4C1E /* ErrorLoggerTests.swift */; };
 		D21919BBB536BA04816CA471 /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C82C61DC5149711E0C326CC /* LocalizationTests.swift */; };
 		KF0000000000000000000001 /* ARKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = KR0000000000000000000001 /* ARKit.framework */; };
@@ -80,6 +82,8 @@
 		CC0000000000000000000001 /* AcoustiScanApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AcoustiScanApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD0000000000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DD0000000000000000000002 /* AcoustiScan.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AcoustiScan.entitlements; sourceTree = "<group>"; };
+		E189FB36B03E227642869FB6 /* DINEvaluation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DINEvaluation.swift; sourceTree = "<group>"; };
+		E24EF1F80CC20877CD865DA9 /* RT60DINView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RT60DINView.swift; sourceTree = "<group>"; };
 		KR0000000000000000000001 /* ARKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ARKit.framework; path = System/Library/Frameworks/ARKit.framework; sourceTree = SDKROOT; };
 		KR0000000000000000000002 /* RealityKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealityKit.framework; path = System/Library/Frameworks/RealityKit.framework; sourceTree = SDKROOT; };
 		KR0000000000000000000003 /* Charts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Charts.framework; path = System/Library/Frameworks/Charts.framework; sourceTree = SDKROOT; };
@@ -206,6 +210,7 @@
 				BB0000000000000000000004 /* RT60ChartView.swift */,
 				BB0000000000000000000005 /* RT60ClassificationView.swift */,
 				BB0000000000000000000014 /* RT60MeasurementView.swift */,
+				E24EF1F80CC20877CD865DA9 /* RT60DINView.swift */,
 			);
 			path = RT60;
 			sourceTree = "<group>";
@@ -250,6 +255,7 @@
 				MR0000000000000000000012 /* SurfaceStore.swift */,
 				MR0000000000000000000013 /* XLSXExporter.swift */,
 				MR0000000000000000000014 /* XLSXImporter.swift */,
+				E189FB36B03E227642869FB6 /* DINEvaluation.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -402,6 +408,8 @@
 				MM0000000000000000000013 /* XLSXExporter.swift in Sources */,
 				MM0000000000000000000014 /* XLSXImporter.swift in Sources */,
 				MM0000000000000000000015 /* LocalizationKeys.swift in Sources */,
+				1D6B87FD3F6CF6BF3C82F0DA /* DINEvaluation.swift in Sources */,
+				C5B9B53320E1010BD7ABEF87 /* RT60DINView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AcoustiScanApp/AcoustiScanApp/Models/DINEvaluation.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Models/DINEvaluation.swift
@@ -1,0 +1,32 @@
+//  DINEvaluation.swift
+//  AcoustiScanApp
+//
+//  Bridges the app's (Sabine-)calculated RT60 spectrum to the package's
+//  norm-faithful DIN 18041 evaluation (asymmetric Bild-2 tolerance band).
+//  Kept separate from SurfaceStore on purpose: importing AcoustiScanConsolidated
+//  here avoids an `AcousticMaterial` name clash with the app's own model.
+
+import Foundation
+import AcoustiScanConsolidated
+
+enum DINEvaluation {
+
+    /// Evaluate a calculated RT60 spectrum (Hz → seconds) against DIN 18041 for
+    /// the given room usage group and volume.
+    /// - Returns: per-octave-band deviations; empty if the volume is not set.
+    static func deviations(
+        spectrum: [Int: Double],
+        roomType: RoomType,
+        volume: Double
+    ) -> [RT60Deviation] {
+        guard volume > 0 else { return [] }
+        let measurements = spectrum
+            .sorted { $0.key < $1.key }
+            .map { RT60Measurement(frequency: $0.key, rt60: $0.value) }
+        return RT60Evaluator.evaluateDINCompliance(
+            measurements: measurements,
+            roomType: roomType,
+            volume: volume
+        )
+    }
+}

--- a/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60ClassificationView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60ClassificationView.swift
@@ -17,15 +17,15 @@ struct RT60ClassificationView: View {
                     Text("Frequenz \(result.frequency) Hz:")
                         .accessibilityHidden(true)
                     Spacer()
-                    Text(String(format: "%.2f s -> %@", result.measuredRT60, result.status.rawValue))
-                        .foregroundColor(result.status == .withinTolerance ? .green : .red)
+                    Text(String(format: "%.2f s -> %@", result.measuredRT60, result.status.displayName))
+                        .foregroundColor(color(for: result.status))
                         .accessibilityHidden(true)
                 }
                 .padding(.vertical, 2)
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Frequency \(result.frequency) Hertz")
                 .accessibilityValue(
-                    String(format: "%.2f seconds, status: %@", result.measuredRT60, result.status.rawValue)
+                    String(format: "%.2f seconds, status: %@", result.measuredRT60, result.status.displayName)
                 )
                 .accessibilityHint(
                     result.status == .withinTolerance ? "Within tolerance" : "Outside tolerance"
@@ -34,5 +34,17 @@ struct RT60ClassificationView: View {
             }
         }
         .padding()
+    }
+
+    /// Map the package's per-status colour intent to a SwiftUI colour
+    /// (non-binary: too-low is orange, not red).
+    private func color(for status: EvaluationStatus) -> Color {
+        switch status.color {
+        case "green": return .green
+        case "red": return .red
+        case "orange": return .orange
+        case "yellow": return .yellow
+        default: return .secondary
+        }
     }
 }

--- a/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60DINView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60DINView.swift
@@ -1,0 +1,70 @@
+//  RT60DINView.swift
+//  AcoustiScanApp
+//
+//  In-app DIN 18041 evaluation: pick the room usage group (A1–A5), evaluate the
+//  calculated RT60 spectrum against the norm-faithful asymmetric tolerance band
+//  (via AcoustiScanConsolidated) and show the per-band result. This wires up the
+//  app's core DIN function, which previously had no UI path.
+
+import SwiftUI
+import AcoustiScanConsolidated
+
+struct RT60DINView: View {
+    @ObservedObject var store: SurfaceStore
+
+    /// Persisted DIN room usage group (raw "A1"…"A5"); kept as String so this
+    /// view owns the selection without modifying SurfaceStore.
+    @AppStorage("din.roomType") private var roomTypeRaw: String = RoomType.a3Education.rawValue
+
+    private var roomType: RoomType {
+        RoomType(rawValue: roomTypeRaw) ?? .a3Education
+    }
+
+    private var deviations: [RT60Deviation] {
+        DINEvaluation.deviations(
+            spectrum: store.calculateRT60Spectrum(),
+            roomType: roomType,
+            volume: store.roomVolume
+        )
+    }
+
+    var body: some View {
+        List {
+            Section(
+                header: Text("Raumnutzungsgruppe (DIN 18041)"),
+                footer: Text("Bewertung der berechneten RT60 gegen das asymmetrische Toleranzband (Bild 2) der gewählten Gruppe.")
+            ) {
+                Picker("Gruppe", selection: $roomTypeRaw) {
+                    ForEach(RoomType.allCases, id: \.self) { type in
+                        Text(type.displayName).tag(type.rawValue)
+                    }
+                }
+                .accessibilityIdentifier("roomTypePicker")
+
+                if store.roomVolume > 0 && !roomType.isVolumeWithinValidRange(store.roomVolume) {
+                    Text("Hinweis: Volumen \(String(format: "%.0f m³", store.roomVolume)) liegt außerhalb des für \(roomType.groupLabel) gültigen Bereichs.")
+                        .font(.footnote)
+                        .foregroundStyle(.orange)
+                        .accessibilityIdentifier("volumeRangeWarning")
+                }
+            }
+
+            if store.roomVolume <= 0 {
+                Section {
+                    Text("Kein Raumvolumen gesetzt – erst Maße eingeben oder scannen.")
+                        .foregroundStyle(.secondary)
+                }
+            } else if deviations.isEmpty {
+                Section {
+                    Text("Keine bewertbaren Bänder – Materialien/Absorption fehlen.")
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Section {
+                    RT60ClassificationView(deviations: deviations)
+                }
+            }
+        }
+        .navigationTitle("DIN 18041")
+    }
+}

--- a/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60DINView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60DINView.swift
@@ -66,5 +66,12 @@ struct RT60DINView: View {
             }
         }
         .navigationTitle("DIN 18041")
+        .onAppear {
+            // Normalize a possibly-stale/corrupt stored value so the Picker
+            // selection always matches a valid RoomType tag.
+            if RoomType(rawValue: roomTypeRaw) == nil {
+                roomTypeRaw = RoomType.a3Education.rawValue
+            }
+        }
     }
 }

--- a/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60View.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/RT60/RT60View.swift
@@ -44,6 +44,13 @@ struct RT60View: View {
                     Label("Impulsmessung (Mikrofon)", systemImage: "waveform")
                 }
                 .accessibilityIdentifier("openMeasurementLink")
+
+                NavigationLink {
+                    RT60DINView(store: store)
+                } label: {
+                    Label("DIN 18041-Auswertung", systemImage: "checkmark.seal")
+                }
+                .accessibilityIdentifier("openDINLink")
             }
         }
         .navigationTitle("Nachhallzeiten")


### PR DESCRIPTION
## Ziel (EKS-Engpass: App-Kernfunktion)
Die App führte **bislang gar keine DIN-18041-Bewertung** durch — kein `RoomType`, und `RT60ClassificationView` war nirgends eingebunden. Das ist der eigentliche Engpass (und Vorbedingung für jeden DIN-Report). Dieser PR schaltet die **Kernfunktion** frei.

## Was
- **`DINEvaluation` (App-Helfer):** mappt das (Sabine-)berechnete RT60-Spektrum → `RT60Evaluator.evaluateDINCompliance` des Pakets = **norm-treues, asymmetrisches Bild-2-Toleranzband**. Bewusst getrennt von `SurfaceStore` gehalten (vermeidet `AcousticMaterial`-Namenskonflikt zwischen App- und Paket-Modul).
- **`RT60DINView`:** Auswahl der Raumnutzungsgruppe **A1–A5** (`RoomType`, persistiert via `@AppStorage`) + Anzeige der Bewertung über die vorhandene, bisher unverdrahtete `RT60ClassificationView`; Hinweis bei Volumen außerhalb des gültigen Bereichs.
- **`RT60View`:** `NavigationLink` „DIN 18041-Auswertung".

## Anti-Fassade
`RT60View` referenziert `RT60DINView`, das `DINEvaluation` → das Paket nutzt. Fehlt eine Datei im Target oder bricht etwas, wird die CI **rot**.

## Verifikation (ehrlich)
- ✅ **CI iOS-Build** kompiliert App inkl. der neuen DIN-Anbindung (= xcodeproj-Wiring + Paket-Aufruf korrekt).
- ✅ Die **DIN-Mathematik** ist bereits im Paket getestet (`RT60EvaluatorTests`, `DIN18041Tests`).
- ⏭️ **Kein** eigener App-Test für den dünnen `DINEvaluation`-Wrapper in diesem PR: er bräuchte eine SPM-Produkt-Abhängigkeit im **Test-Target** (fragil) für eine triviale Delegation. Separat nachrüstbar, wenn mehr App-Tests Paket-Typen brauchen.
- ❌ Laufzeit-UI (Picker/Anzeige am Gerät) wie üblich nicht auto-getestet.

Nächster Schritt darauf aufbauend: echter PDF-Report via `ConsolidatedPDFExporter` (#293) — jetzt möglich, da `roomType` + `dinResults` vorhanden sind.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBWACSFXfR1uYfiGJS5xFa)_