### PR TITLE
Echter PDF-Report in der App via ConsolidatedPDFExporter (Closes #293)

### DIFF
--- a/AcoustiScanApp/AcoustiScanApp.xcodeproj/project.pbxproj
+++ b/AcoustiScanApp/AcoustiScanApp.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		52A23908CB3563EACF2067FB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C844B7827888F3E31637EECC /* Foundation.framework */; };
 		635F5DA43922D1A59793D4D2 /* MaterialManagerXLSXTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91BC90510829E31A2952D24 /* MaterialManagerXLSXTests.swift */; };
 		99141265D7F4E5A63067A5FF /* AcoustiScanUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1FAF9E201B55B21A60C9CF /* AcoustiScanUITests.swift */; };
+		A4C83B04DB74625C99F114AD /* ReportBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E56F27E8C8BF956483FF91 /* ReportBuilder.swift */; };
 		AA0000000000000000000001 /* AcoustiScanApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000001 /* AcoustiScanApp.swift */; };
 		AA0000000000000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000002 /* ContentView.swift */; };
 		AA0000000000000000000003 /* RT60View.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000003 /* RT60View.swift */; };
@@ -57,6 +58,7 @@
 
 /* Begin PBXFileReference section */
 		2D9975929754D1C31D0C4C1E /* ErrorLoggerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorLoggerTests.swift; sourceTree = "<group>"; };
+		41E56F27E8C8BF956483FF91 /* ReportBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReportBuilder.swift; sourceTree = "<group>"; };
 		70FB041E4788DB4C92281EA2 /* en */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7C82C61DC5149711E0C326CC /* LocalizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
 		A6F49369DA611D08BF86A4C6 /* AcoustiScanAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AcoustiScanAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -256,6 +258,7 @@
 				MR0000000000000000000013 /* XLSXExporter.swift */,
 				MR0000000000000000000014 /* XLSXImporter.swift */,
 				E189FB36B03E227642869FB6 /* DINEvaluation.swift */,
+				41E56F27E8C8BF956483FF91 /* ReportBuilder.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -410,6 +413,7 @@
 				MM0000000000000000000015 /* LocalizationKeys.swift in Sources */,
 				1D6B87FD3F6CF6BF3C82F0DA /* DINEvaluation.swift in Sources */,
 				C5B9B53320E1010BD7ABEF87 /* RT60DINView.swift in Sources */,
+				A4C83B04DB74625C99F114AD /* ReportBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AcoustiScanApp/AcoustiScanApp/Models/ReportBuilder.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Models/ReportBuilder.swift
@@ -11,11 +11,13 @@ import AcoustiScanConsolidated
 
 enum ReportBuilder {
 
-    private static let standardFrequencies = [125, 250, 500, 1000, 2000, 4000, 8000]
-
     /// Build `ReportData` for the PDF report from the current room state.
     static func makeReportData(store: SurfaceStore, roomType: RoomType) -> ReportData {
-        let spectrum = store.calculateRT60Spectrum()
+        // Restrict to the bands DIN actually evaluates for this group so that
+        // rt60Measurements and dinResults align (no "Status: Unbekannt" rows,
+        // e.g. 8000 Hz, or 125/4000 Hz for A5).
+        let evaluated = Set(roomType.evaluationFrequencies)
+        let spectrum = store.calculateRT60Spectrum().filter { evaluated.contains($0.key) }
 
         let measurements = spectrum
             .sorted { $0.key < $1.key }
@@ -28,7 +30,7 @@ enum ReportBuilder {
         )
 
         let surfaces: [AcousticSurface] = store.surfaces.map { surface in
-            let coefficients: [Int: Double] = standardFrequencies.reduce(into: [:]) { dict, frequency in
+            let coefficients: [Int: Double] = AbsorptionData.standardFrequencies.reduce(into: [:]) { dict, frequency in
                 dict[frequency] = surface.material.map { Double($0.absorptionCoefficient(at: frequency)) } ?? 0.0
             }
             let material = AcoustiScanConsolidated.AcousticMaterial(

--- a/AcoustiScanApp/AcoustiScanApp/Models/ReportBuilder.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Models/ReportBuilder.swift
@@ -1,0 +1,53 @@
+//  ReportBuilder.swift
+//  AcoustiScanApp
+//
+//  Maps the app's room state (SurfaceStore) + selected DIN room type into the
+//  package's `ReportData`, so the norm-faithful `ConsolidatedPDFExporter` can
+//  render the PDF. The package `AcousticMaterial` is fully qualified to avoid a
+//  name clash with the app's own `AcousticMaterial`.
+
+import Foundation
+import AcoustiScanConsolidated
+
+enum ReportBuilder {
+
+    private static let standardFrequencies = [125, 250, 500, 1000, 2000, 4000, 8000]
+
+    /// Build `ReportData` for the PDF report from the current room state.
+    static func makeReportData(store: SurfaceStore, roomType: RoomType) -> ReportData {
+        let spectrum = store.calculateRT60Spectrum()
+
+        let measurements = spectrum
+            .sorted { $0.key < $1.key }
+            .map { RT60Measurement(frequency: $0.key, rt60: $0.value) }
+
+        let dinResults = DINEvaluation.deviations(
+            spectrum: spectrum,
+            roomType: roomType,
+            volume: store.roomVolume
+        )
+
+        let surfaces: [AcousticSurface] = store.surfaces.map { surface in
+            let coefficients: [Int: Double] = standardFrequencies.reduce(into: [:]) { dict, frequency in
+                dict[frequency] = surface.material.map { Double($0.absorptionCoefficient(at: frequency)) } ?? 0.0
+            }
+            let material = AcoustiScanConsolidated.AcousticMaterial(
+                name: surface.material?.name ?? "—",
+                absorptionCoefficients: coefficients
+            )
+            return AcousticSurface(name: surface.name, area: surface.area, material: material)
+        }
+
+        return ReportData(
+            date: ISO8601DateFormatter().string(from: Date()),
+            roomType: roomType,
+            volume: store.roomVolume,
+            rt60Measurements: measurements,
+            dinResults: dinResults,
+            acousticFrameworkResults: [:],   // 48-parameter framework not computed in-app
+            surfaces: surfaces,
+            recommendations: [],
+            metadata: ["roomName": store.roomName]
+        )
+    }
+}

--- a/AcoustiScanApp/AcoustiScanApp/Views/Export/ExportView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/Export/ExportView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AcoustiScanConsolidated
 
 struct ExportView: View {
     @ObservedObject var store: SurfaceStore
@@ -11,7 +12,7 @@ struct ExportView: View {
                 .accessibilityAddTraits(.isHeader)
                 .accessibilityIdentifier("exportTitle")
 
-            NavigationLink(destination: PDFExportPlaceholderView(store: store)) {
+            NavigationLink(destination: PDFReportExportView(store: store)) {
                 Label(
                     LocalizationKeys.exportRT60AsPDF
                         .localized(comment: "Export RT60 report as PDF"),
@@ -34,60 +35,75 @@ struct ExportView: View {
     }
 }
 
-// Placeholder view for PDF export until full integration with ReportExport module
-struct PDFExportPlaceholderView: View {
+/// Real PDF report export: builds `ReportData` from the room state and renders it
+/// with the norm-faithful `ConsolidatedPDFExporter` (RT60 = Sabine calculation,
+/// DIN 18041 evaluation), then shares the resulting PDF.
+struct PDFReportExportView: View {
     @ObservedObject var store: SurfaceStore
+    @AppStorage("din.roomType") private var roomTypeRaw: String = RoomType.a3Education.rawValue
+
+    @State private var shareURL: URL?
+    @State private var showShare = false
+    @State private var errorMessage: String?
+
+    private var roomType: RoomType { RoomType(rawValue: roomTypeRaw) ?? .a3Education }
 
     var body: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "doc.richtext")
-                .font(.system(size: 60))
-                .foregroundColor(.blue)
-                .accessibilityLabel("PDF document icon")
-                .accessibilityIdentifier("pdfIcon")
-
-            Text(LocalizationKeys.pdfExport.localized(comment: "PDF Export title"))
-                .font(.title2)
-                .fontWeight(.bold)
-                .accessibilityAddTraits(.isHeader)
-                .accessibilityIdentifier("pdfExportTitle")
-
-            Text(LocalizationKeys.featureInIntegration.localized(comment: "Feature in integration message"))
-                .font(.body)
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal)
-                .accessibilityLabel("Feature in integration")
-                .accessibilityIdentifier("integrationMessage")
-
-            // Show basic room info
-            VStack(alignment: .leading, spacing: 10) {
-                Text("\(LocalizationKeys.room.localized(comment: "Room label")): \(store.roomName)")
-                    .accessibilityLabel("Room name")
-                    .accessibilityValue(store.roomName)
-                    .accessibilityIdentifier("roomNameText")
-                Text(
-                    "\(LocalizationKeys.volume.localized(comment: "Volume label")): "
-                    + "\(String(format: "%.1f m³", store.roomVolume))"
-                )
-                    .accessibilityLabel("Room volume")
-                    .accessibilityValue(String(format: "%.1f cubic meters", store.roomVolume))
-                    .accessibilityIdentifier("roomVolumeText")
-                Text("\(LocalizationKeys.surfaces.localized(comment: "Surfaces label")): \(store.surfaces.count)")
-                    .accessibilityLabel("Number of surfaces")
-                    .accessibilityValue("\(store.surfaces.count) surfaces")
-                    .accessibilityIdentifier("surfacesCountText")
+        List {
+            Section(
+                header: Text("Bericht"),
+                footer: Text("Erzeugt ein PDF-Gutachten: RT60 nach Sabine berechnet (keine Messung), DIN-18041-Bewertung der Gruppe \(roomType.groupLabel).")
+            ) {
+                LabeledContent("Raum", value: store.roomName)
+                LabeledContent("Volumen", value: String(format: "%.1f m³", store.roomVolume))
+                LabeledContent("DIN-Gruppe", value: roomType.displayName)
+                LabeledContent("Flächen", value: "\(store.surfaces.count)")
             }
-            .padding()
-            .background(Color.gray.opacity(0.1))
-            .cornerRadius(8)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("Room information summary")
-            .accessibilityIdentifier("roomInfoGroup")
 
-            Spacer()
+            Section {
+                Button {
+                    generate()
+                } label: {
+                    Label("PDF erzeugen & teilen", systemImage: "square.and.arrow.up")
+                }
+                .disabled(store.roomVolume <= 0)
+                .accessibilityIdentifier("generatePDFButton")
+
+                if store.roomVolume <= 0 {
+                    Text("Kein Raumvolumen – erst Maße eingeben oder scannen.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(.red)
+                        .accessibilityIdentifier("exportError")
+                }
+            }
         }
-        .padding()
-        .navigationTitle(LocalizationKeys.pdfExport.localized(comment: "PDF Export navigation title"))
+        .navigationTitle("PDF-Export")
+        .sheet(isPresented: $showShare) {
+            if let shareURL {
+                ShareSheet(activityItems: [shareURL])
+            }
+        }
+    }
+
+    private func generate() {
+        errorMessage = nil
+        let data = ReportBuilder.makeReportData(store: store, roomType: roomType)
+        guard let pdf = ConsolidatedPDFExporter.generateReport(data: data) else {
+            errorMessage = "PDF konnte nicht erzeugt werden."
+            return
+        }
+        do {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("AcoustiScan-Report.pdf")
+            try pdf.write(to: url)
+            shareURL = url
+            showShare = true
+        } catch {
+            errorMessage = "Speichern fehlgeschlagen: \(error.localizedDescription)"
+        }
     }
 }

--- a/AcoustiScanApp/AcoustiScanApp/Views/Export/ExportView.swift
+++ b/AcoustiScanApp/AcoustiScanApp/Views/Export/ExportView.swift
@@ -92,6 +92,10 @@ struct PDFReportExportView: View {
     private func generate() {
         errorMessage = nil
         let data = ReportBuilder.makeReportData(store: store, roomType: roomType)
+        guard !data.rt60Measurements.isEmpty else {
+            errorMessage = "Keine RT60-Werte – bitte den Flächen Materialien mit Absorption zuweisen."
+            return
+        }
         guard let pdf = ConsolidatedPDFExporter.generateReport(data: data) else {
             errorMessage = "PDF konnte nicht erzeugt werden."
             return


### PR DESCRIPTION
Closes #293.

## Was
Der App-PDF-Export war ein **Platzhalter** („Feature in integration"). Dieser PR macht ihn **echt** — über den bereits im Dependency-Paket vorhandenen, **norm-treuen** `ConsolidatedPDFExporter` (kein neuer Dependency/SPM-Eingriff).

- **`ReportBuilder` (neu):** mappt `SurfaceStore` + gewählte DIN-Gruppe → Paket-`ReportData` (RT60-Spektrum, `dinResults` via `DINEvaluation`, Flächen-Mapping). Paket-`AcousticMaterial` ist **qualifiziert** (vermeidet Namenskonflikt mit dem gleichnamigen App-Modell).
- **`ExportView`:** Platzhalter ersetzt durch echten Export → `ConsolidatedPDFExporter.generateReport` → temporäre `.pdf` → `ShareSheet`. Zeigt Raum/Volumen/DIN-Gruppe/Flächen, deaktiviert bei Volumen 0, Fehleranzeige.

Das PDF enthält die **asymmetrische DIN-18041-Bewertung** (über `dinResults`) und den **ehrlichen Methodik-Hinweis** („RT60 nach Sabine berechnet (Prognose), nicht gemessen … ISO 3382 für messtechnische Abnahme"), der im `ConsolidatedPDFExporter` bereits steckt.

## Baut auf
#295 (DIN-Bewertung verdrahtet) — liefert `roomType` (`@AppStorage`) + `dinResults`, die der Report braucht.

## Verifikation (ehrlich)
- ✅ **CI iOS-Build** kompiliert die ganze Kette (`ExportView` → `ReportBuilder` → `ConsolidatedPDFExporter`).
- ✅ PDF-Rendering + DIN-Mathematik sind im Paket getestet (`ReportExport`/`AcoustiScanConsolidated`-Tests).
- ⏭️ Kein eigener App-Test für den dünnen `ReportBuilder`-Mapper (bräuchte SPM-Dep im Test-Target; siehe frühere Begründung) — separat nachrüstbar.
- ❌ Der tatsächliche **Share-Dialog / das fertige PDF am Gerät** ist wie üblich nicht auto-getestet (nur am iPad).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBWACSFXfR1uYfiGJS5xFa)_